### PR TITLE
Fix unused parameter in ProfileService

### DIFF
--- a/src/main/kotlin/com/ritense/iko/profile/ProfileService.kt
+++ b/src/main/kotlin/com/ritense/iko/profile/ProfileService.kt
@@ -4,7 +4,7 @@ import org.apache.camel.CamelContext
 import org.springframework.stereotype.Service
 
 @Service
-class ProfileService(private val camelContext: CamelContext, context: CamelContext) {
+class ProfileService(private val camelContext: CamelContext) {
 
     fun removeRoutes(profile: Profile) {
         removeRoute("profile_${profile.id}_direct")


### PR DESCRIPTION
## Summary
- remove an unused `CamelContext` parameter from `ProfileService`

## Testing
- `gradlew test` *(fails: No route to host)*