### PR TITLE
Add skeleton OpenKlant connector

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,8 @@ dependencies {
     implementation("org.apache.camel:camel-jq")
     implementation("org.apache.camel:camel-bean")
 
+    implementation(project(":openklant-connector"))
+
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect:3.4.0")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/openklant-connector/build.gradle.kts
+++ b/openklant-connector/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    kotlin("jvm") version "2.2.0"
+    kotlin("plugin.spring") version "2.2.0"
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(platform("org.springframework.boot:spring-boot-dependencies:3.5.4"))
+    implementation(platform("org.apache.camel.springboot:camel-spring-boot-dependencies:4.13.0"))
+
+    implementation("org.apache.camel.springboot:camel-spring-boot")
+    implementation("org.apache.camel.springboot:camel-direct-starter")
+    implementation("org.apache.camel.springboot:camel-rest-starter")
+    implementation("org.apache.camel.springboot:camel-openapi-java-starter")
+    implementation("org.apache.camel:camel-rest-openapi")
+
+    implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantApi.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantApi.kt
@@ -1,0 +1,16 @@
+package com.ritense.iko.connectors.openklant
+
+import org.apache.camel.builder.RouteBuilder
+
+class OpenKlantApi : RouteBuilder() {
+    companion object {
+        val URI = "direct:openKlantApi"
+    }
+
+    override fun configure() {
+        from(URI)
+            .errorHandler(noErrorHandler())
+            .toD("openKlant:\${header.openKlantApiOperation}")
+            .unmarshal().json()
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
@@ -1,6 +1,9 @@
 package com.ritense.iko.connectors.openklant
 
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollen
 import org.apache.camel.CamelContext
 import org.apache.camel.component.rest.openapi.RestOpenApiComponent
 import org.springframework.beans.factory.annotation.Value
@@ -37,4 +40,13 @@ class OpenKlantConfig {
 
     @Bean
     fun openKlantEndpointKlanten() = OpenKlantEndpointKlanten()
+
+    @Bean
+    fun openKlantEndpointKlantcontacten() = OpenKlantEndpointKlantcontacten()
+
+    @Bean
+    fun openKlantEndpointContactmomenten() = OpenKlantEndpointContactmomenten()
+
+    @Bean
+    fun openKlantEndpointRollen() = OpenKlantEndpointRollen()
 }

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
@@ -4,6 +4,12 @@ import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontacten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomenten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollen
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenRollen
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontactenContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomentenKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollenKlanten
 import org.apache.camel.CamelContext
 import org.apache.camel.component.rest.openapi.RestOpenApiComponent
 import org.springframework.beans.factory.annotation.Value
@@ -49,4 +55,22 @@ class OpenKlantConfig {
 
     @Bean
     fun openKlantEndpointRollen() = OpenKlantEndpointRollen()
+
+    @Bean
+    fun openKlantEndpointKlantenContactmomenten() = OpenKlantEndpointKlantenContactmomenten()
+
+    @Bean
+    fun openKlantEndpointKlantenKlantcontacten() = OpenKlantEndpointKlantenKlantcontacten()
+
+    @Bean
+    fun openKlantEndpointKlantenRollen() = OpenKlantEndpointKlantenRollen()
+
+    @Bean
+    fun openKlantEndpointKlantcontactenContactmomenten() = OpenKlantEndpointKlantcontactenContactmomenten()
+
+    @Bean
+    fun openKlantEndpointContactmomentenKlantcontacten() = OpenKlantEndpointContactmomentenKlantcontacten()
+
+    @Bean
+    fun openKlantEndpointRollenKlanten() = OpenKlantEndpointRollenKlanten()
 }

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantConfig.kt
@@ -1,0 +1,40 @@
+package com.ritense.iko.connectors.openklant
+
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
+import org.apache.camel.CamelContext
+import org.apache.camel.component.rest.openapi.RestOpenApiComponent
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.net.URI
+
+@Configuration
+@ConditionalOnProperty(
+    value = ["iko.connectors.openklant.enabled"],
+    havingValue = "true",
+    matchIfMissing = true
+)
+class OpenKlantConfig {
+
+    @Bean
+    fun openKlant(
+        camelContext: CamelContext,
+        @Value("\${iko.connectors.openklant.host}") host: String,
+        @Value("\${iko.connectors.openklant.specificationUri}") specificationUri: URI
+    ) =
+        RestOpenApiComponent(camelContext).apply {
+            this.specificationUri = specificationUri.toString()
+            this.host = host
+            this.produces = "application/json"
+        }
+
+    @Bean
+    fun openKlantApi() = OpenKlantApi()
+
+    @Bean
+    fun openKlantPublicEndpoints() = OpenKlantPublicEndpoints()
+
+    @Bean
+    fun openKlantEndpointKlanten() = OpenKlantEndpointKlanten()
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
@@ -4,6 +4,12 @@ import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontacten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomenten
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollen
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantenRollen
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontactenContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomentenKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollenKlanten
 import org.apache.camel.Exchange
 import org.apache.camel.builder.RouteBuilder
 import org.springframework.http.HttpStatus
@@ -23,6 +29,24 @@ class OpenKlantPublicEndpoints : RouteBuilder() {
 
         id("/openklant/rollen", OpenKlantEndpointRollen.URI)
         endpoint("/openklant/rollen", OpenKlantEndpointRollen.URI)
+
+        id("/openklant/klantenContactmomenten", OpenKlantEndpointKlantenContactmomenten.URI)
+        endpoint("/openklant/klantenContactmomenten", OpenKlantEndpointKlantenContactmomenten.URI)
+
+        id("/openklant/klantenKlantcontacten", OpenKlantEndpointKlantenKlantcontacten.URI)
+        endpoint("/openklant/klantenKlantcontacten", OpenKlantEndpointKlantenKlantcontacten.URI)
+
+        id("/openklant/klantenRollen", OpenKlantEndpointKlantenRollen.URI)
+        endpoint("/openklant/klantenRollen", OpenKlantEndpointKlantenRollen.URI)
+
+        id("/openklant/klantcontactenContactmomenten", OpenKlantEndpointKlantcontactenContactmomenten.URI)
+        endpoint("/openklant/klantcontactenContactmomenten", OpenKlantEndpointKlantcontactenContactmomenten.URI)
+
+        id("/openklant/contactmomentenKlantcontacten", OpenKlantEndpointContactmomentenKlantcontacten.URI)
+        endpoint("/openklant/contactmomentenKlantcontacten", OpenKlantEndpointContactmomentenKlantcontacten.URI)
+
+        id("/openklant/rollenKlanten", OpenKlantEndpointRollenKlanten.URI)
+        endpoint("/openklant/rollenKlanten", OpenKlantEndpointRollenKlanten.URI)
     }
 
     private fun id(uri: String, to: String) {

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
@@ -1,0 +1,49 @@
+package com.ritense.iko.connectors.openklant
+
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
+import org.apache.camel.Exchange
+import org.apache.camel.builder.RouteBuilder
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.AccessDeniedException
+class OpenKlantPublicEndpoints : RouteBuilder() {
+    override fun configure() {
+        handleAccessDeniedException()
+
+        id("/openklant/klanten", OpenKlantEndpointKlanten.URI)
+        endpoint("/openklant/klanten", OpenKlantEndpointKlanten.URI)
+    }
+
+    private fun id(uri: String, to: String) {
+        rest("/endpoints$uri")
+            .get("/{id}")
+            .to("direct:${to}_id")
+
+        from("direct:${to}_id")
+            .errorHandler(noErrorHandler())
+            .setVariable("authorities", constant("ROLE_ENDPOINT_${to.replace("direct:", "").uppercase()}"))
+            .to("direct:auth")
+            .routeId("direct:${to}_api_id")
+            .to(to)
+            .marshal().json()
+    }
+
+    private fun endpoint(uri: String, to: String) {
+        rest("/endpoints$uri")
+            .get()
+            .to("direct:${to}_endpoint")
+
+        from("direct:${to}_endpoint")
+            .errorHandler(noErrorHandler())
+            .setVariable("authorities", constant("ROLE_ENDPOINT_${to.replace("direct:", "").uppercase()}"))
+            .to("direct:auth")
+            .routeId("direct:${to}_api_endpoint")
+            .to(to)
+            .marshal().json()
+    }
+
+    private fun handleAccessDeniedException() {
+        onException(AccessDeniedException::class.java)
+            .handled(true)
+            .setHeader(Exchange.HTTP_RESPONSE_CODE, constant(HttpStatus.UNAUTHORIZED.value()))
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/OpenKlantPublicEndpoints.kt
@@ -1,6 +1,9 @@
 package com.ritense.iko.connectors.openklant
 
 import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlanten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointKlantcontacten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointContactmomenten
+import com.ritense.iko.connectors.openklant.endpoints.OpenKlantEndpointRollen
 import org.apache.camel.Exchange
 import org.apache.camel.builder.RouteBuilder
 import org.springframework.http.HttpStatus
@@ -11,6 +14,15 @@ class OpenKlantPublicEndpoints : RouteBuilder() {
 
         id("/openklant/klanten", OpenKlantEndpointKlanten.URI)
         endpoint("/openklant/klanten", OpenKlantEndpointKlanten.URI)
+
+        id("/openklant/klantcontacten", OpenKlantEndpointKlantcontacten.URI)
+        endpoint("/openklant/klantcontacten", OpenKlantEndpointKlantcontacten.URI)
+
+        id("/openklant/contactmomenten", OpenKlantEndpointContactmomenten.URI)
+        endpoint("/openklant/contactmomenten", OpenKlantEndpointContactmomenten.URI)
+
+        id("/openklant/rollen", OpenKlantEndpointRollen.URI)
+        endpoint("/openklant/rollen", OpenKlantEndpointRollen.URI)
     }
 
     private fun id(uri: String, to: String) {

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpoint.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpoint.kt
@@ -1,0 +1,47 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+import com.ritense.iko.connectors.openklant.OpenKlantApi
+import org.apache.camel.builder.RouteBuilder
+import org.apache.camel.model.RouteDefinition
+
+abstract class OpenKlantEndpoint : RouteBuilder() {
+
+    fun idAndEndpointRoute(uri: String) {
+        from(uri)
+            .errorHandler(noErrorHandler())
+            .choice()
+            .`when`(simple("\${header.id} != null"))
+            .to("${uri}_id")
+            .otherwise()
+            .to("${uri}_endpoint")
+    }
+
+    fun idRoute(
+        uri: String,
+        operation: String,
+        id: String = "uuid",
+        func: (RouteDefinition) -> RouteDefinition = { it }
+    ) {
+        from("${uri}_id")
+            .errorHandler(noErrorHandler())
+            .removeHeaders("*", "id")
+            .setHeader("openKlantApiOperation", constant(operation))
+            .setHeader(id, header("id"))
+            .let(func)
+            .to(OpenKlantApi.URI)
+    }
+
+    fun endpointRoute(
+        uri: String,
+        operation: String,
+        headers: List<String> = listOf("page", "pageSize"),
+        func: (RouteDefinition) -> RouteDefinition = { it }
+    ) {
+        from("${uri}_endpoint")
+            .errorHandler(noErrorHandler())
+            .removeHeaders("*", *headers.toTypedArray())
+            .setHeader("openKlantApiOperation", constant(operation))
+            .let(func)
+            .to(OpenKlantApi.URI)
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointContactmomenten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointContactmomenten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointContactmomenten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointContactmomenten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "contactmoment_read")
+        endpointRoute(URI, "contactmoment_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointContactmomentenKlantcontacten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointContactmomentenKlantcontacten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointContactmomentenKlantcontacten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointContactmomentenKlantcontacten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "contactmoment_klantcontact_read")
+        endpointRoute(URI, "contactmoment_klantcontact_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantcontacten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantcontacten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointKlantcontacten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlantcontacten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klantcontact_read")
+        endpointRoute(URI, "klantcontact_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantcontactenContactmomenten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantcontactenContactmomenten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointKlantcontactenContactmomenten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlantcontactenContactmomenten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klantcontact_contactmoment_read")
+        endpointRoute(URI, "klantcontact_contactmoment_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlanten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlanten.kt
@@ -1,33 +1,13 @@
 package com.ritense.iko.connectors.openklant.endpoints
 
-import com.ritense.iko.connectors.openklant.OpenKlantApi
-import org.apache.camel.builder.RouteBuilder
-
-class OpenKlantEndpointKlanten : RouteBuilder() {
+class OpenKlantEndpointKlanten : OpenKlantEndpoint() {
     companion object {
         val URI = "direct:openKlantEndpointKlanten"
     }
 
     override fun configure() {
-        from(URI)
-            .errorHandler(noErrorHandler())
-            .choice()
-            .`when`(simple("\${header.id} != null"))
-            .to("${URI}_id")
-            .otherwise()
-            .to("${URI}_endpoint")
-
-        from("${URI}_id")
-            .errorHandler(noErrorHandler())
-            .removeHeaders("*", "id")
-            .setHeader("openKlantApiOperation", constant("klant_read"))
-            .setHeader("uuid", header("id"))
-            .to(OpenKlantApi.URI)
-
-        from("${URI}_endpoint")
-            .errorHandler(noErrorHandler())
-            .removeHeaders("*", "page", "pageSize")
-            .setHeader("openKlantApiOperation", constant("klant_list"))
-            .to(OpenKlantApi.URI)
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klant_read")
+        endpointRoute(URI, "klant_list")
     }
 }

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlanten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlanten.kt
@@ -1,0 +1,33 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+import com.ritense.iko.connectors.openklant.OpenKlantApi
+import org.apache.camel.builder.RouteBuilder
+
+class OpenKlantEndpointKlanten : RouteBuilder() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlanten"
+    }
+
+    override fun configure() {
+        from(URI)
+            .errorHandler(noErrorHandler())
+            .choice()
+            .`when`(simple("\${header.id} != null"))
+            .to("${URI}_id")
+            .otherwise()
+            .to("${URI}_endpoint")
+
+        from("${URI}_id")
+            .errorHandler(noErrorHandler())
+            .removeHeaders("*", "id")
+            .setHeader("openKlantApiOperation", constant("klant_read"))
+            .setHeader("uuid", header("id"))
+            .to(OpenKlantApi.URI)
+
+        from("${URI}_endpoint")
+            .errorHandler(noErrorHandler())
+            .removeHeaders("*", "page", "pageSize")
+            .setHeader("openKlantApiOperation", constant("klant_list"))
+            .to(OpenKlantApi.URI)
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenContactmomenten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenContactmomenten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointKlantenContactmomenten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlantenContactmomenten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klant_contactmoment_read")
+        endpointRoute(URI, "klant_contactmoment_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenKlantcontacten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenKlantcontacten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointKlantenKlantcontacten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlantenKlantcontacten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klant_klantcontact_read")
+        endpointRoute(URI, "klant_klantcontact_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenRollen.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointKlantenRollen.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointKlantenRollen : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointKlantenRollen"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "klant_rol_read")
+        endpointRoute(URI, "klant_rol_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointRollen.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointRollen.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointRollen : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointRollen"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "rol_read")
+        endpointRoute(URI, "rol_list")
+    }
+}

--- a/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointRollenKlanten.kt
+++ b/openklant-connector/src/main/kotlin/com/ritense/iko/connectors/openklant/endpoints/OpenKlantEndpointRollenKlanten.kt
@@ -1,0 +1,13 @@
+package com.ritense.iko.connectors.openklant.endpoints
+
+class OpenKlantEndpointRollenKlanten : OpenKlantEndpoint() {
+    companion object {
+        val URI = "direct:openKlantEndpointRollenKlanten"
+    }
+
+    override fun configure() {
+        idAndEndpointRoute(URI)
+        idRoute(URI, "rol_klant_read")
+        endpointRoute(URI, "rol_klant_list")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,2 @@
 rootProject.name = "iko"
+include("openklant-connector")

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,4 +108,8 @@ iko:
             host: # ENV
             specificationUri: "https://raw.githubusercontent.com/maykinmedia/objects-api/3.1.2/src/objects/api/v2/openapi.yaml"
             token: # ENV
+        openklant:
+            enabled: true
+            host: # ENV
+            specificationUri: "https://raw.githubusercontent.com/maykinmedia/open-klant/2.10.0/src/openklant/components/klantinteracties/openapi.yaml"
 


### PR DESCRIPTION
## Summary
- add basic OpenKlant connector with one endpoint for klant resources
- expose OpenKlant configuration and public endpoints
- add OpenKlant settings placeholder to application.yml
- move OpenKlant connector to its own Gradle module

## Testing
- `./gradlew test -q` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_688b34b9463c8326ba637e90823273c5