### PR TITLE
fix: connector id not set for relation calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Integraal Klant & Objectbeeld (IKO)
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square)  
+![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square)  
 
 IKO is a Kotlin/Spring Boot application that uses Apache Camel to integrate with external systems via connectors. It ships with an admin UI and a Docker-based local environment.
 

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
@@ -231,6 +231,7 @@ class AggregatedDataProfileRouteBuilder(
             .routeConfigurationId(GLOBAL_ERROR_HANDLER_CONFIGURATION)
             .routeDescription("[${currentRelation.propertyName}] --> Endpoint")
             .unmarshal().json()
+            .setVariable("connectorId", constant(connectorInstance.connector.id))
             .setVariable("connector", constant(connectorInstance.connector.tag))
             .setVariable("config", constant(connectorInstance.tag))
             .setVariable("operation", constant(connectorEndpoint.operation))


### PR DESCRIPTION
* add missing route variable to relation flow in AggregatedDataProfileRouteBuilder that caused relations to attempt to reuse the adp root connector instead of the one configured for the relation