### PR TITLE
feat: Draft/Final lifecycle for ADP and Connector entities

### DIFF
--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
@@ -25,6 +25,8 @@ import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
@@ -49,6 +51,10 @@ class AggregatedDataProfile(
 
     @Column(name = "is_active", nullable = false)
     var isActive: Boolean = false,
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: EntityStatus = EntityStatus.DRAFT,
 
     @Column(name = "connector_instance_id")
     var connectorInstanceId: UUID,
@@ -77,7 +83,17 @@ class AggregatedDataProfile(
     var aggregatedDataProfileCacheSetting: AggregatedDataProfileCacheSetting,
 ) {
 
+    fun finalize() {
+        require(status == EntityStatus.DRAFT) { "Only DRAFT versions can be finalized" }
+        this.status = EntityStatus.FINAL
+    }
+
+    fun ensureDraft() {
+        require(status == EntityStatus.DRAFT) { "Cannot modify a FINAL version" }
+    }
+
     fun handle(request: AggregatedDataProfileEditForm) {
+        ensureDraft()
         this.roles = Roles(request.roles)
         this.connectorEndpointId = request.connectorEndpointId
         this.connectorInstanceId = request.connectorInstanceId
@@ -90,6 +106,7 @@ class AggregatedDataProfile(
     }
 
     fun addRelation(form: AddRelationForm) {
+        ensureDraft()
         this.relations.add(
             Relation(
                 aggregatedDataProfile = this,
@@ -105,6 +122,7 @@ class AggregatedDataProfile(
     }
 
     fun changeRelation(form: EditRelationForm) {
+        ensureDraft()
         this.relations.removeIf { it.id == form.id }
         this.relations.add(
             Relation(
@@ -125,6 +143,7 @@ class AggregatedDataProfile(
     }
 
     fun removeRelation(request: DeleteRelationForm) {
+        ensureDraft()
         // Remove the selected relation and all its descendants
         val toRemove: MutableSet<UUID> = linkedSetOf()
 

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.aggregateddataprofile.domain
+
+enum class EntityStatus { DRAFT, FINAL }

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
@@ -17,6 +17,7 @@
 package com.ritense.iko.aggregateddataprofile.repository
 
 import com.ritense.iko.aggregateddataprofile.domain.AggregatedDataProfile
+import com.ritense.iko.aggregateddataprofile.domain.EntityStatus
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
@@ -41,6 +42,8 @@ interface AggregatedDataProfileRepository : JpaRepository<AggregatedDataProfile,
 
     fun findAllByIsActiveTrue(): List<AggregatedDataProfile>
     fun findAllByIsActiveTrue(pageable: Pageable = Pageable.unpaged()): Page<AggregatedDataProfile>
+
+    fun findAllByStatus(status: EntityStatus): List<AggregatedDataProfile>
 
     @Query(
         """
@@ -81,6 +84,7 @@ interface AggregatedDataProfileRepository : JpaRepository<AggregatedDataProfile,
         ,       adp.name as name
         ,       adp.version.value as version
         ,       adp.isActive as active
+        ,       adp.status as status
         FROM    AggregatedDataProfile adp
         WHERE   adp.name = :name
         ORDER BY adp.version.value DESC
@@ -98,5 +102,6 @@ interface AggregatedDataProfileRepository : JpaRepository<AggregatedDataProfile,
         val name: String
         val version: String
         val active: Boolean
+        val status: EntityStatus
     }
 }

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
@@ -18,10 +18,12 @@ package com.ritense.iko.aggregateddataprofile.service
 
 import com.ritense.iko.aggregateddataprofile.camel.AggregatedDataProfileRouteBuilder
 import com.ritense.iko.aggregateddataprofile.domain.AggregatedDataProfile
+import com.ritense.iko.aggregateddataprofile.domain.EntityStatus
 import com.ritense.iko.aggregateddataprofile.repository.AggregatedDataProfileRepository
 import com.ritense.iko.cache.processor.CacheProcessor
 import com.ritense.iko.connectors.repository.ConnectorEndpointRepository
 import com.ritense.iko.connectors.repository.ConnectorInstanceRepository
+import com.ritense.iko.connectors.service.ConnectorService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.apache.camel.CamelContext
 import org.springframework.boot.context.event.ApplicationReadyEvent
@@ -36,6 +38,7 @@ internal class AggregatedDataProfileService(
     private val aggregatedDataProfileRepository: AggregatedDataProfileRepository,
     private val connectorEndpointRepository: ConnectorEndpointRepository,
     private val connectorInstanceRepository: ConnectorInstanceRepository,
+    private val connectorService: ConnectorService,
     private val ikoCacheProcessor: CacheProcessor,
 ) {
 
@@ -145,6 +148,100 @@ internal class AggregatedDataProfileService(
         logger.debug { "Created new version ${newAdp.name} v${newAdp.version} with ${newAdp.relations.size} relations" }
 
         return aggregatedDataProfileRepository.save(newAdp)
+    }
+
+    @Transactional(readOnly = true)
+    fun previewFinalization(id: UUID): FinalizationImpact {
+        val adp = aggregatedDataProfileRepository.findById(id)
+            .orElseThrow { NoSuchElementException("Profile not found: $id") }
+        require(adp.status == EntityStatus.DRAFT) { "Already finalized" }
+
+        val allInstanceIds = buildSet {
+            add(adp.connectorInstanceId)
+            adp.relations.forEach { add(it.connectorInstanceId) }
+        }
+
+        val draftConnectors = mutableListOf<com.ritense.iko.connectors.domain.Connector>()
+        val errors = mutableListOf<String>()
+
+        for (instanceId in allInstanceIds) {
+            val instance = connectorInstanceRepository.findById(instanceId).orElse(null)
+            if (instance == null) {
+                errors.add("Connector instance $instanceId not found")
+                continue
+            }
+            val connector = instance.connector
+            if (connector.status == EntityStatus.DRAFT) {
+                draftConnectors.add(connector)
+            }
+        }
+
+        val connectorImpacts = draftConnectors.distinctBy { it.id }.map { connector ->
+            val instances = connectorInstanceRepository.findByConnector(connector)
+            val instanceIds = instances.map { it.id }.toSet()
+
+            val allDraftAdps = aggregatedDataProfileRepository.findAllByStatus(EntityStatus.DRAFT)
+            val affectedAdps = allDraftAdps
+                .filter { it.id != adp.id }
+                .filter { otherAdp ->
+                    val otherInstanceIds = buildSet {
+                        add(otherAdp.connectorInstanceId)
+                        otherAdp.relations.forEach { add(it.connectorInstanceId) }
+                    }
+                    otherInstanceIds.any { it in instanceIds }
+                }
+                .map { AffectedAdp(it.id, it.name, it.version.value) }
+
+            try {
+                connectorService.validateConnectorCode(connector.connectorCode, connector.tag)
+            } catch (e: Exception) {
+                errors.add("Connector '${connector.tag}' v${connector.version} has invalid code: ${e.message}")
+            }
+            val endpoints = connectorEndpointRepository.findByConnector(connector)
+            if (endpoints.isEmpty()) {
+                errors.add("Connector '${connector.tag}' v${connector.version} has no endpoints")
+            }
+
+            ConnectorImpact(
+                connectorId = connector.id,
+                connectorName = connector.name,
+                connectorTag = connector.tag,
+                connectorVersion = connector.version.value,
+                affectedDraftAdps = affectedAdps,
+            )
+        }
+
+        return FinalizationImpact(
+            adpId = adp.id,
+            adpName = adp.name,
+            connectorsToFinalize = connectorImpacts,
+            canFinalize = errors.isEmpty(),
+            errors = errors,
+        )
+    }
+
+    @Transactional
+    fun finalizeProfile(id: UUID): AggregatedDataProfile {
+        val adp = aggregatedDataProfileRepository.findById(id)
+            .orElseThrow { NoSuchElementException("Profile not found: $id") }
+        require(adp.status == EntityStatus.DRAFT) { "Already finalized" }
+
+        val allInstanceIds = buildSet {
+            add(adp.connectorInstanceId)
+            adp.relations.forEach { add(it.connectorInstanceId) }
+        }
+
+        for (instanceId in allInstanceIds) {
+            val instance = connectorInstanceRepository.findById(instanceId)
+                .orElseThrow { NoSuchElementException("Connector instance $instanceId not found") }
+            val connector = instance.connector
+            if (connector.status == EntityStatus.DRAFT) {
+                connectorService.finalizeConnector(connector.id)
+            }
+        }
+
+        adp.finalize()
+        return aggregatedDataProfileRepository.save(adp)
     }
 
     companion object {

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.aggregateddataprofile.service
+
+import java.util.UUID
+
+internal data class FinalizationImpact(
+    val adpId: UUID,
+    val adpName: String,
+    val connectorsToFinalize: List<ConnectorImpact>,
+    val canFinalize: Boolean,
+    val errors: List<String>,
+)
+
+internal data class ConnectorImpact(
+    val connectorId: UUID,
+    val connectorName: String,
+    val connectorTag: String,
+    val connectorVersion: String,
+    val affectedDraftAdps: List<AffectedAdp>,
+)
+
+internal data class AffectedAdp(
+    val id: UUID,
+    val name: String,
+    val version: String,
+)

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
@@ -16,9 +16,12 @@
 
 package com.ritense.iko.connectors.domain
 
+import com.ritense.iko.aggregateddataprofile.domain.EntityStatus
 import jakarta.persistence.Column
 import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
@@ -42,7 +45,19 @@ class Connector(
     var isActive: Boolean = false,
     @Column(name = "connector_code")
     var connectorCode: String,
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: EntityStatus = EntityStatus.DRAFT,
 ) {
+    fun finalize() {
+        require(status == EntityStatus.DRAFT) { "Only DRAFT versions can be finalized" }
+        this.status = EntityStatus.FINAL
+    }
+
+    fun ensureDraft() {
+        require(status == EntityStatus.DRAFT) { "Cannot modify a FINAL version" }
+    }
+
     /**
      * Creates a new version of this Connector.
      * Endpoints and instances are NOT copied here - they must be copied separately.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.iko.connectors.repository
 
+import com.ritense.iko.aggregateddataprofile.domain.EntityStatus
 import com.ritense.iko.connectors.domain.Connector
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -42,6 +43,7 @@ interface ConnectorRepository : JpaRepository<Connector, UUID> {
         ,       c.tag as tag
         ,       c.version.value as version
         ,       c.isActive as active
+        ,       c.status as status
         FROM    Connector c
         WHERE   c.tag = :tag
         ORDER BY c.version.value DESC
@@ -55,5 +57,6 @@ interface ConnectorRepository : JpaRepository<Connector, UUID> {
         val tag: String
         val version: String
         val active: Boolean
+        val status: EntityStatus
     }
 }

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -117,6 +117,20 @@ class ConnectorService(
         logger.debug { "Removed routes for connector ${connector.tag} (group: $groupName)" }
     }
 
+    @Transactional
+    fun finalizeConnector(id: UUID): Connector {
+        val connector = connectorRepository.findById(id)
+            .orElseThrow { NoSuchElementException("Connector not found: $id") }
+
+        validateConnectorCode(connector.connectorCode, connector.tag)
+
+        val endpoints = connectorEndpointRepository.findByConnector(connector)
+        require(endpoints.isNotEmpty()) { "Connector must have at least one endpoint to be finalized" }
+
+        connector.finalize()
+        return connectorRepository.save(connector)
+    }
+
     /**
      * Activates a specific version of a Connector.
      * Deactivates any currently active version and loads routes for the new active version.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -590,6 +590,24 @@ internal class AggregatedDataProfileController(
         }
     }
 
+    @PostMapping("/aggregated-data-profiles/{id}/finalize/preview")
+    fun finalizePreview(
+        @PathVariable id: UUID,
+    ): ModelAndView {
+        val impact = aggregatedDataProfileService.previewFinalization(id)
+        return ModelAndView("fragments/internal/versioning/finalize-preview-modal")
+            .addObject("impact", impact)
+    }
+
+    @PostMapping("/aggregated-data-profiles/{id}/finalize")
+    fun finalizeProfile(
+        @PathVariable id: UUID,
+        @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
+    ): ModelAndView {
+        aggregatedDataProfileService.finalizeProfile(id)
+        return details(id, isHxRequest)
+    }
+
     @PostMapping("/aggregated-data-profiles/{id}/activate")
     fun activateVersion(
         @PathVariable id: UUID,

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -146,6 +146,7 @@ class ConnectorController(
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
         val connector = connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }
+        connector.ensureDraft()
 
         if (bindingResult.hasErrors()) {
             httpServletResponse.setHeader("HX-Retarget", "#connector-code")
@@ -315,6 +316,8 @@ class ConnectorController(
         bindingResult: BindingResult,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
+        connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }.ensureDraft()
+
         if (bindingResult.hasErrors()) {
             return ModelAndView(
                 "fragments/internal/connector/formCreateConnectorInstanceConfig :: form",
@@ -385,6 +388,8 @@ class ConnectorController(
         bindingResult: BindingResult,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
+        connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }.ensureDraft()
+
         if (bindingResult.hasErrors()) {
             val connector =
                 connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }
@@ -442,6 +447,8 @@ class ConnectorController(
         @RequestHeader(HomeController.Companion.HX_REQUEST_HEADER) isHxRequest: Boolean = false,
         response: HttpServletResponse,
     ): ModelAndView {
+        connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }.ensureDraft()
+
         if (bindingResult.hasErrors()) {
             return ModelAndView(
                 "fragments/internal/connector/formCreateConnectorInstance :: form",
@@ -531,6 +538,7 @@ class ConnectorController(
         }
 
         val connector = connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }
+        connector.ensureDraft()
 
         var connectorEndpoint =
             ConnectorEndpoint(
@@ -562,9 +570,10 @@ class ConnectorController(
         @PathVariable id: UUID,
         @PathVariable endpointId: UUID,
     ): ModelAndView {
-        connectorEndpointRepository.deleteById(endpointId)
-
         val connector = connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }
+        connector.ensureDraft()
+
+        connectorEndpointRepository.deleteById(endpointId)
 
         return ModelAndView(
             "fragments/internal/connector/detailsPageConnector :: endpoints-table",
@@ -583,9 +592,10 @@ class ConnectorController(
         @PathVariable id: UUID,
         @PathVariable instanceId: UUID,
     ): ModelAndView {
-        connectorInstanceRepository.deleteById(instanceId)
-
         val connector = connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }
+        connector.ensureDraft()
+
+        connectorInstanceRepository.deleteById(instanceId)
         val instances = connectorInstanceRepository.findByConnector(connector)
 
         return ModelAndView(
@@ -603,6 +613,8 @@ class ConnectorController(
         @PathVariable instanceId: UUID,
         @PathVariable roleId: UUID,
     ): ModelAndView {
+        connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }.ensureDraft()
+
         connectorEndpointRoleRepository.deleteById(roleId)
         val connectorInstance =
             connectorInstanceRepository
@@ -625,6 +637,8 @@ class ConnectorController(
         @PathVariable instanceId: UUID,
         @PathVariable configKey: String,
     ): ModelAndView {
+        connectorRepository.findById(id).orElseThrow { NoSuchElementException("Connector not found") }.ensureDraft()
+
         val instance =
             connectorInstanceRepository
                 .findById(instanceId)
@@ -720,6 +734,15 @@ class ConnectorController(
                 addObject("errors", bindingResult)
             }
         }
+    }
+
+    @PostMapping("/{id}/finalize")
+    fun finalizeConnector(
+        @PathVariable id: UUID,
+        @RequestHeader(HomeController.Companion.HX_REQUEST_HEADER) isHxRequest: Boolean = false,
+    ): ModelAndView {
+        connectorService.finalizeConnector(id)
+        return details(id, isHxRequest)
     }
 
     @PostMapping("/{id}/activate")

--- a/src/main/resources/db/migration/V2026.03.12.1__add_draft_final_status.sql
+++ b/src/main/resources/db/migration/V2026.03.12.1__add_draft_final_status.sql
@@ -1,0 +1,11 @@
+-- Add status column to connector
+ALTER TABLE connector ADD COLUMN status VARCHAR(10) NOT NULL DEFAULT 'DRAFT';
+
+-- Existing active versions are treated as finalized (already in production)
+UPDATE connector SET status = 'FINAL' WHERE is_active = TRUE;
+
+-- Add status column to aggregated_data_profile
+ALTER TABLE aggregated_data_profile ADD COLUMN status VARCHAR(10) NOT NULL DEFAULT 'DRAFT';
+
+-- Existing active versions are treated as finalized (already in production)
+UPDATE aggregated_data_profile SET status = 'FINAL' WHERE is_active = TRUE;

--- a/src/main/resources/db/migration/V2026.03.12.1__add_draft_final_status.sql
+++ b/src/main/resources/db/migration/V2026.03.12.1__add_draft_final_status.sql
@@ -1,11 +1,5 @@
 -- Add status column to connector
 ALTER TABLE connector ADD COLUMN status VARCHAR(10) NOT NULL DEFAULT 'DRAFT';
 
--- Existing active versions are treated as finalized (already in production)
-UPDATE connector SET status = 'FINAL' WHERE is_active = TRUE;
-
 -- Add status column to aggregated_data_profile
 ALTER TABLE aggregated_data_profile ADD COLUMN status VARCHAR(10) NOT NULL DEFAULT 'DRAFT';
-
--- Existing active versions are treated as finalized (already in production)
-UPDATE aggregated_data_profile SET status = 'FINAL' WHERE is_active = TRUE;

--- a/src/main/resources/db/migration/V2026.03.12.2__fix_active_versions_status_to_final.sql
+++ b/src/main/resources/db/migration/V2026.03.12.2__fix_active_versions_status_to_final.sql
@@ -1,3 +1,0 @@
--- Fix active versions that were not migrated to FINAL status
-UPDATE connector SET status = 'FINAL' WHERE is_active = TRUE AND status = 'DRAFT';
-UPDATE aggregated_data_profile SET status = 'FINAL' WHERE is_active = TRUE AND status = 'DRAFT';

--- a/src/main/resources/db/migration/V2026.03.12.2__fix_active_versions_status_to_final.sql
+++ b/src/main/resources/db/migration/V2026.03.12.2__fix_active_versions_status_to_final.sql
@@ -1,0 +1,3 @@
+-- Fix active versions that were not migrated to FINAL status
+UPDATE connector SET status = 'FINAL' WHERE is_active = TRUE AND status = 'DRAFT';
+UPDATE aggregated_data_profile SET status = 'FINAL' WHERE is_active = TRUE AND status = 'DRAFT';

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -552,6 +552,7 @@ cds-form-item {
 
 .page-title-version-select cds-dropdown {
     min-width: 150px;
+    width: max-content;
 }
 
 .page-title-version-select cds-dropdown::part(trigger-button) {

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
@@ -62,6 +62,10 @@
                             >
                                 (<span
                                     th:text="${instance.connector.name + ' ' + instance.connector.version.value}"
+                                ></span>
+                                -
+                                <span
+                                    th:text="${instance.connector.status.name()}"
                                 ></span
                                 >)
                                 <span th:text="${instance.name}"></span>

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
@@ -37,6 +37,7 @@
                         entityType='aggregated-data-profile',
                         currentVersion=${aggregatedDataProfile.version.value},
                         isActiveVersion=${aggregatedDataProfile.isActive},
+                        status=${aggregatedDataProfile.status},
                         versions=${versions}
                     )}"
                 ></div>

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit.html
@@ -70,6 +70,7 @@
                                                         hx-get="/admin/aggregated-data-profiles/create/endpoints"
                                                         hx-trigger="cds-select-selected"
                                                         hx-target="#formEndpoints"
+                                                        th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                                                         th:attr="invalid=${errors?.getFieldError('connectorInstanceId') != null or (errors != null and #lists.isEmpty(connectorEndpoints))} ? 'true' : null,
                                                                  invalid-text=${(errors != null and #lists.isEmpty(connectorEndpoints)) ? 'No endpoints configured for selected connector' : errors?.getFieldError('connectorInstanceId')?.defaultMessage},
                                                                  value=${form.connectorInstanceId}
@@ -81,6 +82,10 @@
                                                         >
                                                             (<span
                                                                 th:text="${instance.connector.name + ' ' + instance.connector.version.value}"
+                                                            ></span>
+                                                            -
+                                                            <span
+                                                                th:text="${instance.connector.status.name()}"
                                                             ></span
                                                             >)
                                                             <span
@@ -97,6 +102,7 @@
                                                         <cds-select
                                                             label-text="Select an connector endpoint"
                                                             name="connectorEndpointId"
+                                                            th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                                                             th:attr="invalid=${#lists.isEmpty(connectorEndpoints) or errors?.getFieldError('connectorEndpointId') != null} ? 'true' : null,
                                                                      invalid-text=${#lists.isEmpty(connectorEndpoints) ? 'No endpoints configured for selected connector' : errors?.getFieldError('connectorEndpointId')?.defaultMessage},
                                                                      value=${#lists.isEmpty(connectorEndpoints) ? '' : form?.connectorEndpointId}"
@@ -118,6 +124,7 @@
                                             <cds-text-input
                                                 name="roles"
                                                 label="Roles"
+                                                th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                                                 th:attr="invalid=${errors?.getFieldError('roles') != null} ? 'true' : null,
                                                                          invalid-text=${errors?.getFieldError('roles')?.defaultMessage},
                                                                          value=${form?.roles}"
@@ -222,6 +229,7 @@
                                                 data-textarea="#endpointTransformCode"
                                                 th:data-initial="${form?.endpointTransform}"
                                                 data-theme="lightgray-theme"
+                                                th:attr="data-readonly=${aggregatedDataProfile?.status?.name() != 'DRAFT'} ? 'true' : null"
                                                 th:class="${errors?.getFieldError('endpointTransform') != null} ? 'monaco-editor-style monaco-editor-error' : 'monaco-editor-style'"
                                             ></div>
                                             <div
@@ -275,6 +283,7 @@
                                                 data-textarea="#resultTransformCode"
                                                 th:data-initial="${form?.resultTransform}"
                                                 data-theme="lightgray-theme"
+                                                th:attr="data-readonly=${aggregatedDataProfile?.status?.name() != 'DRAFT'} ? 'true' : null"
                                                 th:class="${errors?.getFieldError('resultTransform') != null} ? 'monaco-editor-style monaco-editor-error' : 'monaco-editor-style'"
                                             ></div>
                                             <div

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
@@ -103,6 +103,7 @@
 
                 <cds-button
                     kind="secondary"
+                    th:disabled="${aggregatedDataProfile.status.name() != 'DRAFT'}"
                     th:attr="
                                     hx-get=@{'/admin/aggregated-data-profiles/' + ${aggregatedDataProfile.id} + '/relations/create'},
                                     hx-vals=|js:{ sourceId: document.querySelector('#selectedSourceId').value }|,

--- a/src/main/resources/templates/fragments/internal/connector/detailsPageConnector.html
+++ b/src/main/resources/templates/fragments/internal/connector/detailsPageConnector.html
@@ -33,6 +33,7 @@
                         entityType='connector',
                         currentVersion=${connector.version.value},
                         isActiveVersion=${connector.isActive},
+                        status=${connector.status},
                         versions=${versions}
                     )}"
                 ></div>
@@ -90,6 +91,7 @@
                                 data-editor-selector="#connector-editor"
                                 style="display: none"
                                 onclick="toggleEditorMode(false, 'save-button', 'edit-code-button', 'connector-editor');"
+                                th:disabled="${connector.status.name() != 'DRAFT'}"
                             >
                                 Save
                             </cds-button>
@@ -97,6 +99,7 @@
                             <cds-button
                                 id="edit-code-button"
                                 onclick="toggleEditorMode(true, 'save-button', 'edit-code-button', 'connector-editor');"
+                                th:disabled="${connector.status.name() != 'DRAFT'}"
                             >
                                 Edit code
                             </cds-button>
@@ -150,6 +153,7 @@
                                         th:hx-get="@{|/admin/connectors/${connector.id}/endpoints/create|}"
                                         hx-target="#modal-container"
                                         kind="primary"
+                                        th:disabled="${connector.status.name() != 'DRAFT'}"
                                     >
                                         Add endpoint
                                         <svg
@@ -199,6 +203,7 @@
                                             leave-delay-ms="0"
                                             close-on-activation
                                             hx-on:click="event.stopPropagation()"
+                                            th:disabled="${connector.status.name() != 'DRAFT'}"
                                         >
                                             <svg
                                                 focusable="false"
@@ -265,6 +270,7 @@
                                         th:hx-get="@{|/admin/connectors/${connector.id}/instances/create|}"
                                         hx-target="#modal-container"
                                         kind="primary"
+                                        th:disabled="${connector.status.name() != 'DRAFT'}"
                                     >
                                         Add instance
                                         <svg
@@ -322,6 +328,7 @@
                                             leave-delay-ms="0"
                                             close-on-activation
                                             hx-on:click="event.stopPropagation()"
+                                            th:disabled="${connector.status.name() != 'DRAFT'}"
                                         >
                                             <svg
                                                 focusable="false"

--- a/src/main/resources/templates/fragments/internal/relation/add.html
+++ b/src/main/resources/templates/fragments/internal/relation/add.html
@@ -69,6 +69,10 @@
                     >
                         (<span
                             th:text="${instance.connector.name + ' ' + instance.connector.version.value}"
+                        ></span>
+                        -
+                        <span
+                            th:text="${instance.connector.status.name()}"
                         ></span
                         >)
                         <span th:text="${instance.name}"></span>

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -71,6 +71,10 @@
                     >
                         (<span
                             th:text="${instance.connector.name + ' ' + instance.connector.version.value}"
+                        ></span>
+                        -
+                        <span
+                            th:text="${instance.connector.status.name()}"
                         ></span
                         >)
                         <span th:text="${instance.name}"></span>

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
@@ -1,0 +1,87 @@
+<!--
+ Copyright (C) 2026 Ritense BV, the Netherlands.
+
+ Licensed under EUPL, Version 1.2 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+<cds-modal
+    id="active-modal"
+    prevent-close-on-click-outside="true"
+    open="true"
+    size="md"
+>
+    <cds-modal-header>
+        <cds-modal-close-button></cds-modal-close-button>
+        <cds-modal-heading
+            >Finalize <span th:text="${impact.adpName}"></span
+        ></cds-modal-heading>
+    </cds-modal-header>
+    <cds-modal-body>
+        <p th:if="${#lists.isEmpty(impact.connectorsToFinalize)}">
+            All referenced connectors are already finalized. This will make the
+            ADP immutable.
+        </p>
+
+        <div th:if="${!#lists.isEmpty(impact.connectorsToFinalize)}">
+            <p>The following connectors will also be finalized:</p>
+            <div
+                th:each="conn : ${impact.connectorsToFinalize}"
+                style="margin-bottom: var(--cds-spacing-05)"
+            >
+                <strong
+                    th:text="|${conn.connectorTag} v${conn.connectorVersion}|"
+                ></strong>
+                <span> (DRAFT → FINAL)</span>
+                <div
+                    th:if="${!#lists.isEmpty(conn.affectedDraftAdps)}"
+                    style="
+                        margin-top: var(--cds-spacing-02);
+                        color: var(--cds-text-secondary);
+                    "
+                >
+                    <span>Also referenced by: </span>
+                    <span th:each="affected, stat : ${conn.affectedDraftAdps}">
+                        <span
+                            th:text="|${affected.name} v${affected.version}|"
+                        ></span>
+                        <span th:if="${!stat.last}">, </span>
+                    </span>
+                </div>
+            </div>
+        </div>
+
+        <cds-inline-notification
+            th:each="error : ${impact.errors}"
+            kind="error"
+            title="Validation Error"
+            th:attr="subtitle=${error}"
+            hide-close-button="true"
+        >
+        </cds-inline-notification>
+    </cds-modal-body>
+    <cds-modal-footer>
+        <cds-modal-footer-button data-modal-close="" kind="secondary"
+            >Cancel</cds-modal-footer-button
+        >
+        <cds-modal-footer-button
+            th:hx-post="@{|/admin/aggregated-data-profiles/${impact.adpId}/finalize|}"
+            hx-target="#view-panel"
+            hx-swap="innerHTML"
+            hx-on::after-request="document.getElementById('active-modal')?.removeAttribute('open')"
+            th:disabled="${!impact.canFinalize}"
+            th:attr="aria-disabled=${!impact.canFinalize} ? 'true' : null"
+            kind="danger"
+            >Finalize</cds-modal-footer-button
+        >
+    </cds-modal-footer>
+</cds-modal>

--- a/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
+++ b/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
@@ -51,6 +51,20 @@
                                         >
                                             Active
                                         </cds-tag>
+                                        <cds-tag
+                                            th:if="${version.status.name() == 'DRAFT'}"
+                                            type="warm-gray"
+                                            size="sm"
+                                        >
+                                            Draft
+                                        </cds-tag>
+                                        <cds-tag
+                                            th:if="${version.status.name() == 'FINAL'}"
+                                            type="blue"
+                                            size="sm"
+                                        >
+                                            Final
+                                        </cds-tag>
                                     </div>
                                 </cds-dropdown-item>
                             </cds-dropdown>
@@ -65,6 +79,19 @@
                             size="md"
                         >
                             <cds-menu>
+                                <cds-menu-item
+                                    th:if="${status.name() == 'DRAFT'}"
+                                    label="Finalize"
+                                    th:hx-post="@{|/admin/${entityType}s/${entityId}/${entityType == 'aggregated-data-profile' ? 'finalize/preview' : 'finalize'}|}"
+                                    th:hx-target="${entityType == 'aggregated-data-profile' ? '#modal-container' : '#view-panel'}"
+                                    hx-swap="innerHTML"
+                                ></cds-menu-item>
+                                <cds-menu-item
+                                    th:if="${status.name() == 'FINAL'}"
+                                    label="Finalize"
+                                    disabled
+                                    aria-disabled="true"
+                                ></cds-menu-item>
                                 <cds-menu-item
                                     label="Create New Version"
                                     th:hx-get="@{|/admin/${entityType}s/${entityId}/versions/create|}"

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
@@ -375,6 +375,119 @@ class AggregatedDataProfileTest {
         assertThat(profile.relationsOf(targetId).map { it.id }).containsOnly(matchId)
     }
 
+    @Test
+    fun `new profile has DRAFT status`() {
+        val profile = createProfile()
+        assertThat(profile.status).isEqualTo(EntityStatus.DRAFT)
+    }
+
+    @Test
+    fun `finalize changes status to FINAL`() {
+        val profile = createProfile()
+        profile.finalize()
+        assertThat(profile.status).isEqualTo(EntityStatus.FINAL)
+    }
+
+    @Test
+    fun `finalize on FINAL throws`() {
+        val profile = createProfile()
+        profile.finalize()
+        assertThatThrownBy { profile.finalize() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Only DRAFT versions can be finalized")
+    }
+
+    @Test
+    fun `handle on FINAL throws`() {
+        val profile = createProfile()
+        profile.finalize()
+        val form = AggregatedDataProfileEditForm(
+            id = profile.id,
+            name = "updated",
+            roles = "ROLE_UPDATED",
+            connectorInstanceId = UUID.randomUUID(),
+            connectorEndpointId = UUID.randomUUID(),
+            endpointTransform = ".",
+            resultTransform = ".",
+            cacheEnabled = false,
+            cacheTimeToLive = 0,
+            version = Version("1.0.0"),
+        )
+        assertThatThrownBy { profile.handle(form) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot modify a FINAL version")
+    }
+
+    @Test
+    fun `addRelation on FINAL throws`() {
+        val profile = createProfile()
+        profile.finalize()
+        val form = AddRelationForm(
+            aggregatedDataProfileId = profile.id,
+            sourceId = profile.id,
+            connectorInstanceId = UUID.randomUUID(),
+            connectorEndpointId = UUID.randomUUID(),
+            sourceToEndpointMapping = ".",
+            resultTransform = ".",
+            propertyName = "test",
+        )
+        assertThatThrownBy { profile.addRelation(form) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot modify a FINAL version")
+    }
+
+    @Test
+    fun `changeRelation on FINAL throws`() {
+        val profile = createProfile()
+        profile.finalize()
+        val form = EditRelationForm(
+            aggregatedDataProfileId = profile.id,
+            id = UUID.randomUUID(),
+            sourceId = profile.id,
+            sourceToEndpointMapping = ".",
+            resultTransform = ".",
+            propertyName = "test",
+            connectorInstanceId = UUID.randomUUID(),
+            connectorEndpointId = UUID.randomUUID(),
+            cacheEnabled = false,
+            cacheTimeToLive = 0,
+        )
+        assertThatThrownBy { profile.changeRelation(form) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot modify a FINAL version")
+    }
+
+    @Test
+    fun `removeRelation on FINAL throws`() {
+        val profile = createProfile()
+        profile.finalize()
+        assertThatThrownBy { profile.removeRelation(DeleteRelationForm(profile.id, UUID.randomUUID())) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot modify a FINAL version")
+    }
+
+    @Test
+    fun `createNewVersion from FINAL produces DRAFT`() {
+        val profile = createProfile()
+        profile.finalize()
+        val newVersion = profile.createNewVersion("2.0.0")
+        assertThat(newVersion.status).isEqualTo(EntityStatus.DRAFT)
+    }
+
+    @Test
+    fun `create produces DRAFT`() {
+        val form = AggregatedDataProfileAddForm(
+            name = "pets",
+            roles = "ROLE_ADMIN",
+            endpointTransform = ".",
+            resultTransform = ".",
+            connectorInstanceId = UUID.randomUUID(),
+            connectorEndpointId = UUID.randomUUID(),
+        )
+        val profile = AggregatedDataProfile.create(form)
+        assertThat(profile.status).isEqualTo(EntityStatus.DRAFT)
+    }
+
     private fun createProfile(): AggregatedDataProfile = AggregatedDataProfile(
         id = UUID.randomUUID(),
         name = "pets",

--- a/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
@@ -16,7 +16,9 @@
 
 package com.ritense.iko.connectors.domain
 
+import com.ritense.iko.aggregateddataprofile.domain.EntityStatus
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.util.UUID
 
@@ -41,6 +43,51 @@ class ConnectorTest {
         assertThat(newVersion.name).isEqualTo(connector.name)
         assertThat(newVersion.connectorCode).isEqualTo(connector.connectorCode)
         assertThat(newVersion.id).isNotEqualTo(connector.id)
+    }
+
+    @Test
+    fun `new connector has DRAFT status`() {
+        val connector = createConnector()
+        assertThat(connector.status).isEqualTo(EntityStatus.DRAFT)
+    }
+
+    @Test
+    fun `finalize changes status to FINAL`() {
+        val connector = createConnector()
+        connector.finalize()
+        assertThat(connector.status).isEqualTo(EntityStatus.FINAL)
+    }
+
+    @Test
+    fun `finalize on FINAL throws`() {
+        val connector = createConnector()
+        connector.finalize()
+        assertThatThrownBy { connector.finalize() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Only DRAFT versions can be finalized")
+    }
+
+    @Test
+    fun `ensureDraft on DRAFT succeeds`() {
+        val connector = createConnector()
+        connector.ensureDraft()
+    }
+
+    @Test
+    fun `ensureDraft on FINAL throws`() {
+        val connector = createConnector()
+        connector.finalize()
+        assertThatThrownBy { connector.ensureDraft() }
+            .isInstanceOf(IllegalArgumentException::class.java)
+            .hasMessageContaining("Cannot modify a FINAL version")
+    }
+
+    @Test
+    fun `createNewVersion from FINAL produces DRAFT`() {
+        val connector = createConnector()
+        connector.finalize()
+        val newVersion = connector.createNewVersion("2.0.0")
+        assertThat(newVersion.status).isEqualTo(EntityStatus.DRAFT)
     }
 
     private fun createConnector(): Connector = Connector(


### PR DESCRIPTION
## Summary

- Add **Draft/Final lifecycle** to both `AggregatedDataProfile` and `Connector` entities. Every version starts as `DRAFT` (fully editable) and can be finalized into `FINAL` (immutable).
- **ADP cascade finalization**: when an ADP is finalized, all referenced DRAFT connectors are cascade-finalized in a single transaction. A preview modal shows the impact before confirming.
- **Connectors** can also be finalized independently (direct finalization, no preview).
- **UI controls are disabled** (not hidden) on FINAL entities — dropdowns, text inputs, Monaco editors become read-only, overflow menus are disabled.
- **Status badges** (Draft/Final) shown in version dropdowns and connector instance selectors across all forms.
- Flyway migration adds `status` column to both tables, migrating existing active versions to `FINAL`.

## Test plan

- [x] Unit tests for domain-level finalize/ensureDraft guards (ADP + Connector)
- [x] Unit tests for status on new entities, createNewVersion producing DRAFT
- [x] `./gradlew test` passes
- [x] `./gradlew spotlessCheck` passes
- [x] Manual: finalize a DRAFT connector via overflow menu → status becomes FINAL, controls disabled
- [x] Manual: finalize a DRAFT ADP → preview modal shows impact, confirm cascade-finalizes connectors
- [x] Manual: version dropdown shows Draft (warm-gray) / Final (blue) tags, sized to widest item
- [x] Manual: connector instance dropdowns show DRAFT/FINAL status across ADP and relation forms
- [x] Integration tests (`./gradlew integrationTest`)