### PR TITLE
feat: isActive filter toggle, status/active columns, DRAFT-only deletion

### DIFF
--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
@@ -49,32 +49,46 @@ interface AggregatedDataProfileRepository : JpaRepository<AggregatedDataProfile,
         """
         SELECT  adp.id
         ,       adp.name
+        ,       adp.version
+        ,       adp.is_active AS active
+        ,       adp.status
         FROM    aggregated_data_profile adp
+        WHERE   (:isActive IS NULL OR adp.is_active = :isActive)
         """,
         countQuery = """
         SELECT  count(*)
         FROM    aggregated_data_profile adp
+        WHERE   (:isActive IS NULL OR adp.is_active = :isActive)
         """,
         nativeQuery = true,
     )
-    fun findAllBy(pageable: Pageable): Page<AggregatedDataProfileListItem>
+    fun findAllBy(
+        @Param("isActive") isActive: Boolean?,
+        pageable: Pageable,
+    ): Page<AggregatedDataProfileListItem>
 
     @Query(
         """
         SELECT  adp.id
         ,       adp.name
+        ,       adp.version
+        ,       adp.is_active AS active
+        ,       adp.status
         FROM    aggregated_data_profile adp
         WHERE   LOWER(adp.name) LIKE LOWER(CONCAT('%', :name, '%'))
+        AND     (:isActive IS NULL OR adp.is_active = :isActive)
         """,
         countQuery = """
         SELECT  COUNT(*)
         FROM    aggregated_data_profile adp
         WHERE   LOWER(adp.name) LIKE LOWER(CONCAT('%', :name, '%'))
+        AND     (:isActive IS NULL OR adp.is_active = :isActive)
         """,
         nativeQuery = true,
     )
     fun findAllByName(
         @Param("name") name: String,
+        @Param("isActive") isActive: Boolean?,
         pageable: Pageable,
     ): Page<AggregatedDataProfileListItem>
 
@@ -92,9 +106,15 @@ interface AggregatedDataProfileRepository : JpaRepository<AggregatedDataProfile,
     )
     fun findVersionsByName(@Param("name") name: String): List<AggregatedDataProfileVersionProjection>
 
+    @Query("SELECT COUNT(*) > 0 FROM aggregated_data_profile WHERE name COLLATE \"C\" = :name", nativeQuery = true)
+    fun existsByName(@Param("name") name: String): Boolean
+
     interface AggregatedDataProfileListItem {
         val id: String
         val name: String
+        val version: String
+        val active: Boolean
+        val status: String
     }
 
     interface AggregatedDataProfileVersionProjection {

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
@@ -36,6 +36,9 @@ interface ConnectorRepository : JpaRepository<Connector, UUID> {
 
     fun findAllByIsActiveTrue(): List<Connector>
 
+    @Query("SELECT c FROM Connector c WHERE (:isActive IS NULL OR c.isActive = :isActive)")
+    fun findAllByIsActive(@Param("isActive") isActive: Boolean?): List<Connector>
+
     @Query(
         """
         SELECT  c.id as id

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -104,10 +104,12 @@ internal class AggregatedDataProfileController(
     @GetMapping("/aggregated-data-profiles")
     fun list(
         @RequestParam(required = false, defaultValue = "") query: String,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean?,
         @PageableDefault(size = PAGE_DEFAULT) pageable: Pageable,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
-        val page = aggregatedDataProfileRepository.findAllByIsActiveTrue(pageable)
+        val activeFilter = if (isActive == true) true else null
+        val page = aggregatedDataProfileRepository.findAllBy(activeFilter, pageable)
         val connectorInstancesCount = connectorInstanceRepository.findAll().size
         val endpointsCount = connectorEndpointRepository.findAll().size
         val creationAllowed = connectorInstancesCount > 0 && endpointsCount > 0
@@ -117,6 +119,7 @@ internal class AggregatedDataProfileController(
                 addObject("aggregatedDataProfiles", page.content)
                 addObject("page", page)
                 addObject("query", query)
+                addObject("isActive", isActive)
             }
         } else {
             ModelAndView("$BASE_FRAGMENT_ADP/listPage").apply {
@@ -124,6 +127,7 @@ internal class AggregatedDataProfileController(
                 addObject("aggregatedDataProfiles", page.content)
                 addObject("page", page)
                 addObject("query", query)
+                addObject("isActive", isActive)
                 addObject("menuItems", menuItems)
                 addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
                 addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
@@ -134,9 +138,11 @@ internal class AggregatedDataProfileController(
     @GetMapping("/aggregated-data-profiles/pagination")
     fun pagination(
         @RequestParam(required = false, defaultValue = "") query: String,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean?,
         @PageableDefault(size = PAGE_DEFAULT) pageable: Pageable,
     ): ModelAndView {
-        val page = aggregatedDataProfileRepository.findAll(pageable)
+        val activeFilter = if (isActive == true) true else null
+        val page = aggregatedDataProfileRepository.findAllBy(activeFilter, pageable)
         val connectorInstanceCount = connectorInstanceRepository.findAll().size
         val endpointsCount = connectorEndpointRepository.findAll().size
         val creationAllowed = connectorInstanceCount > 0 && endpointsCount > 0
@@ -145,6 +151,7 @@ internal class AggregatedDataProfileController(
                 addObject("aggregatedDataProfiles", page.content)
                 addObject("page", page)
                 addObject("query", query)
+                addObject("isActive", isActive)
                 addObject("creationAllowed", creationAllowed)
                 addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
                 addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
@@ -155,14 +162,16 @@ internal class AggregatedDataProfileController(
     @GetMapping("/aggregated-data-profiles/filter")
     fun filter(
         @RequestParam(required = false, defaultValue = "") query: String,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean?,
         @PageableDefault(size = PAGE_DEFAULT) pageable: Pageable,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): List<ModelAndView> {
+        val activeFilter = if (isActive == true) true else null
         val page =
             if (query.isBlank()) {
-                aggregatedDataProfileRepository.findAllBy(pageable)
+                aggregatedDataProfileRepository.findAllBy(activeFilter, pageable)
             } else {
-                aggregatedDataProfileRepository.findAllByName(query.trim(), pageable)
+                aggregatedDataProfileRepository.findAllByName(query.trim(), activeFilter, pageable)
             }
         val connectorInstanceCount = connectorInstanceRepository.findAll().size
         val endpointsCount = connectorEndpointRepository.findAll().size
@@ -175,6 +184,7 @@ internal class AggregatedDataProfileController(
                     addObject("aggregatedDataProfiles", page.content)
                     addObject("page", page)
                     addObject("query", query)
+                    addObject("isActive", isActive)
                     addObject("creationAllowed", creationAllowed)
                     addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
                     addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
@@ -184,6 +194,7 @@ internal class AggregatedDataProfileController(
                     addObject("aggregatedDataProfiles", page.content)
                     addObject("page", page)
                     addObject("query", query)
+                    addObject("isActive", isActive)
                     addObject("creationAllowed", creationAllowed)
                     addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
                     addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
@@ -198,6 +209,7 @@ internal class AggregatedDataProfileController(
                     addObject("aggregatedDataProfiles", page.content)
                     addObject("page", page)
                     addObject("query", query)
+                    addObject("isActive", isActive)
                     addObject("creationAllowed", creationAllowed)
                     addObject("menuItems", menuItems)
                     addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
@@ -538,7 +550,7 @@ internal class AggregatedDataProfileController(
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
         httpServletResponse.setHeader("HX-Reswap", "innerHTML")
 
-        return list(query = "", pageable = Pageable.ofSize(PAGE_DEFAULT), isHxRequest = isHxRequest)
+        return list(query = "", isActive = true, pageable = Pageable.ofSize(PAGE_DEFAULT), isHxRequest = isHxRequest)
     }
 
     @DeleteMapping("/aggregated-data-profiles/{id}/cache")

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -45,6 +45,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.ModelAndView
 import java.util.UUID
 
@@ -71,9 +72,11 @@ class ConnectorController(
      */
     @GetMapping()
     fun list(
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean?,
         @RequestHeader(HomeController.Companion.HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
-        val connectors = connectorRepository.findAllByIsActiveTrue()
+        val activeFilter = if (isActive == true) true else null
+        val connectors = connectorRepository.findAllByIsActive(activeFilter)
 
         return ModelAndView(
             "fragments/internal/connector/listPageConnectors" +
@@ -83,6 +86,7 @@ class ConnectorController(
                 },
             mapOf(
                 "connectors" to connectors,
+                "isActive" to isActive,
                 "username" to SecurityContextHelper.getUserPropertyByKey("name"),
                 "email" to SecurityContextHelper.getUserPropertyByKey("email"),
             ),

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
@@ -31,17 +31,15 @@ class UniqueAggregatedDataProfileValidator(
     ): Boolean {
         if (form.name.isBlank()) return false
 
-        val existing = aggregatedDataProfileRepository.findByName(form.name)
-        val isValid = existing == null || existing.id == form.id
-
-        if (!isValid) {
+        val exists = aggregatedDataProfileRepository.existsByName(form.name)
+        if (exists) {
             context.disableDefaultConstraintViolation()
             context
                 .buildConstraintViolationWithTemplate("Name already exists/in use, please choose another.")
-                .addPropertyNode("name") // point to 'name' field
+                .addPropertyNode("name")
                 .addConstraintViolation()
         }
 
-        return isValid
+        return !exists
     }
 }

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filterResults.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filterResults.html
@@ -17,7 +17,7 @@
 <th:block th:fragment="profile-filter-results">
     <cds-table-body id="search-results">
         <cds-table-row th:if="${!creationAllowed}" class="not-clickable">
-            <cds-table-cell colspan="3" class="app--table-cell-empty">
+            <cds-table-cell colspan="5" class="app--table-cell-empty">
                 <div class="app--empty-notice">
                     <img
                         th:src="@{/assets/emptystate-error.svg}"
@@ -43,7 +43,7 @@
             th:if="${creationAllowed and #lists.isEmpty(aggregatedDataProfiles)}"
             class="not-clickable"
         >
-            <cds-table-cell colspan="3" class="app--table-cell-empty">
+            <cds-table-cell colspan="5" class="app--table-cell-empty">
                 <div class="app--empty-notice">
                     <img
                         th:src="@{/assets/emptystate-error.svg}"
@@ -76,8 +76,21 @@
             <cds-table-cell
                 th:text="${aggregatedDataProfile.version}"
             ></cds-table-cell>
+            <cds-table-cell>
+                <cds-tag
+                    th:type="${aggregatedDataProfile.status == 'FINAL' ? 'green' : 'cool-gray'}"
+                    th:text="${aggregatedDataProfile.status}"
+                ></cds-tag>
+            </cds-table-cell>
+            <cds-table-cell>
+                <cds-tag
+                    th:type="${aggregatedDataProfile.active ? 'green' : 'cool-gray'}"
+                    th:text="${aggregatedDataProfile.active ? 'Yes' : 'No'}"
+                ></cds-tag>
+            </cds-table-cell>
             <cds-table-cell class="app--table-cell-actions">
                 <cds-overflow-menu
+                    th:if="${aggregatedDataProfile.status == 'DRAFT'}"
                     enter-delay-ms="3000"
                     leave-delay-ms="0"
                     close-on-activation

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filterResults.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filterResults.html
@@ -89,6 +89,7 @@
                 ></cds-tag>
             </cds-table-cell>
             <cds-table-cell class="app--table-cell-actions">
+                <div th:if="${aggregatedDataProfile.status != 'DRAFT'}"></div>
                 <cds-overflow-menu
                     th:if="${aggregatedDataProfile.status == 'DRAFT'}"
                     enter-delay-ms="3000"

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -44,21 +44,44 @@
                     }"
                 >
                 </cds-table-toolbar-search>
-                <cds-checkbox
-                    id="active-filter-toggle"
-                    th:checked="${isActive}"
-                    hx-get="/admin/aggregated-data-profiles/filter"
-                    hx-target="#search-results"
-                    hx-swap="outerHTML"
-                    hx-trigger="cds-checkbox-changed"
-                    hx-vals="js:{
-                        isActive: event.detail.checked,
-                        size: document.querySelector('#pagination-container')?.__pageSize || 10,
-                        page: 0,
-                        query: document.querySelector('#search-bar')?.value || ''
-                    }"
-                    >Active only</cds-checkbox
-                >
+                <cds-overflow-menu>
+                    <svg
+                        focusable="false"
+                        preserveAspectRatio="xMidYMid meet"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="var(--cds-icon-primary)"
+                        slot="icon"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 32 32"
+                        aria-hidden="true"
+                    >
+                        <path
+                            d="M27 16.76V16v-.77l1.92-1.68A2 2 0 0029.3 11l-2.36-4a2 2 0 00-1.73-1 2 2 0 00-.64.1l-2.43.82a11.35 11.35 0 00-1.31-.75l-.51-2.52a2 2 0 00-2-1.61h-4.68a2 2 0 00-2 1.61l-.51 2.52a11.48 11.48 0 00-1.32.75l-2.38-.86A2 2 0 006.79 6a2 2 0 00-1.73 1L2.7 11a2 2 0 00.41 2.51L5 15.24v1.53l-1.89 1.68A2 2 0 002.7 21l2.36 4a2 2 0 001.73 1 2 2 0 00.64-.1l2.43-.82a11.35 11.35 0 001.31.75l.51 2.52a2 2 0 002 1.61h4.72a2 2 0 002-1.61l.51-2.52a11.48 11.48 0 001.32-.75l2.42.82a2 2 0 00.64.1 2 2 0 001.73-1l2.28-4a2 2 0 00-.41-2.51zM25.21 24l-3.43-1.16a8.86 8.86 0 01-2.71 1.57L18.36 28h-4.72l-.71-3.55a9.36 9.36 0 01-2.7-1.57L6.79 24l-2.36-4 2.72-2.4a8.9 8.9 0 010-3.13L4.43 12l2.36-4 3.43 1.16a8.86 8.86 0 012.71-1.57L13.64 4h4.72l.71 3.55a9.36 9.36 0 012.7 1.57L25.21 8l2.36 4-2.72 2.4a8.9 8.9 0 010 3.13L27.57 20zM16 22a6 6 0 116-6 5.94 5.94 0 01-6 6zm0-10a4 4 0 104 4 4 4 0 00-4-4z"
+                        ></path>
+                    </svg>
+                    <span slot="tooltip-content">Filters</span>
+                    <cds-overflow-menu-body flipped="">
+                        <cds-overflow-menu-item style="pointer-events: none">
+                            <cds-checkbox
+                                id="active-filter-toggle"
+                                th:checked="${isActive}"
+                                hx-get="/admin/aggregated-data-profiles/filter"
+                                hx-target="#search-results"
+                                hx-swap="outerHTML"
+                                hx-trigger="cds-checkbox-changed"
+                                hx-vals="js:{
+                                    isActive: event.detail.checked,
+                                    size: document.querySelector('#pagination-container')?.__pageSize || 10,
+                                    page: 0,
+                                    query: document.querySelector('#search-bar')?.value || ''
+                                }"
+                                style="pointer-events: auto"
+                                >Active only</cds-checkbox
+                            >
+                        </cds-overflow-menu-item>
+                    </cds-overflow-menu-body>
+                </cds-overflow-menu>
                 <cds-button
                     hx-get="/admin/aggregated-data-profiles/create"
                     hx-target="#modal-container"

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -39,8 +39,26 @@
                     hx-target="#search-results"
                     hx-swap="outerHTML"
                     hx-push-url="true"
+                    hx-vals="js:{
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true
+                    }"
                 >
                 </cds-table-toolbar-search>
+                <cds-checkbox
+                    id="active-filter-toggle"
+                    th:checked="${isActive}"
+                    hx-get="/admin/aggregated-data-profiles/filter"
+                    hx-target="#search-results"
+                    hx-swap="outerHTML"
+                    hx-trigger="cds-checkbox-changed"
+                    hx-vals="js:{
+                        isActive: event.detail.checked,
+                        size: document.querySelector('#pagination-container')?.__pageSize || 10,
+                        page: 0,
+                        query: document.querySelector('#search-bar')?.value || ''
+                    }"
+                    >Active only</cds-checkbox
+                >
                 <cds-button
                     hx-get="/admin/aggregated-data-profiles/create"
                     hx-target="#modal-container"
@@ -83,12 +101,15 @@
                         sort: 'name,' + ({ none: '', ascending: 'ASC', descending: 'DESC' }[event.detail.sortDirection] ?? ''),
                         size: document.querySelector('#pagination-container').__pageSize,
                         page: document.querySelector('#pagination-container').__page - 1,
-                        query: document.querySelector('#search-bar').value
+                        query: document.querySelector('#search-bar').value,
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true
                         }"
                 >
                     Name
                 </cds-table-header-cell>
                 <cds-table-header-cell size="sm">Version</cds-table-header-cell>
+                <cds-table-header-cell size="sm">Status</cds-table-header-cell>
+                <cds-table-header-cell size="sm">Active</cds-table-header-cell>
                 <cds-table-header-cell></cds-table-header-cell>
             </cds-table-header-row>
         </cds-table-head>

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -33,7 +33,8 @@
         hx-vals="js:{
                       size: event.detail.pageSize,
                       page: event.detail.page - 1,
-                      query: document.querySelector('#search-bar').value
+                      query: document.querySelector('#search-bar').value,
+                      isActive: document.querySelector('#active-filter-toggle')?.checked ?? true
                     }"
     >
         <cds-select-item value="10">10</cds-select-item>

--- a/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
+++ b/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
@@ -34,18 +34,43 @@
                 <cds-table id="profile-table">
                     <cds-table-toolbar slot="toolbar">
                         <cds-table-toolbar-content>
-                            <cds-checkbox
-                                id="active-filter-toggle"
-                                th:checked="${isActive}"
-                                hx-get="/admin/connectors"
-                                hx-target="#view-panel"
-                                hx-swap="innerHTML"
-                                hx-trigger="cds-checkbox-changed"
-                                hx-vals="js:{
-                                    isActive: event.detail.checked
-                                }"
-                                >Active only</cds-checkbox
-                            >
+                            <cds-overflow-menu>
+                                <svg
+                                    focusable="false"
+                                    preserveAspectRatio="xMidYMid meet"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    fill="var(--cds-icon-primary)"
+                                    slot="icon"
+                                    width="16"
+                                    height="16"
+                                    viewBox="0 0 32 32"
+                                    aria-hidden="true"
+                                >
+                                    <path
+                                        d="M27 16.76V16v-.77l1.92-1.68A2 2 0 0029.3 11l-2.36-4a2 2 0 00-1.73-1 2 2 0 00-.64.1l-2.43.82a11.35 11.35 0 00-1.31-.75l-.51-2.52a2 2 0 00-2-1.61h-4.68a2 2 0 00-2 1.61l-.51 2.52a11.48 11.48 0 00-1.32.75l-2.38-.86A2 2 0 006.79 6a2 2 0 00-1.73 1L2.7 11a2 2 0 00.41 2.51L5 15.24v1.53l-1.89 1.68A2 2 0 002.7 21l2.36 4a2 2 0 001.73 1 2 2 0 00.64-.1l2.43-.82a11.35 11.35 0 001.31.75l.51 2.52a2 2 0 002 1.61h4.72a2 2 0 002-1.61l.51-2.52a11.48 11.48 0 001.32-.75l2.42.82a2 2 0 00.64.1 2 2 0 001.73-1l2.28-4a2 2 0 00-.41-2.51zM25.21 24l-3.43-1.16a8.86 8.86 0 01-2.71 1.57L18.36 28h-4.72l-.71-3.55a9.36 9.36 0 01-2.7-1.57L6.79 24l-2.36-4 2.72-2.4a8.9 8.9 0 010-3.13L4.43 12l2.36-4 3.43 1.16a8.86 8.86 0 012.71-1.57L13.64 4h4.72l.71 3.55a9.36 9.36 0 012.7 1.57L25.21 8l2.36 4-2.72 2.4a8.9 8.9 0 010 3.13L27.57 20zM16 22a6 6 0 116-6 5.94 5.94 0 01-6 6zm0-10a4 4 0 104 4 4 4 0 00-4-4z"
+                                    ></path>
+                                </svg>
+                                <span slot="tooltip-content"> Filters </span>
+                                <cds-overflow-menu-body flipped="">
+                                    <cds-overflow-menu-item
+                                        style="pointer-events: none"
+                                    >
+                                        <cds-checkbox
+                                            id="active-filter-toggle"
+                                            th:checked="${isActive}"
+                                            hx-get="/admin/connectors"
+                                            hx-target="#view-panel"
+                                            hx-swap="innerHTML"
+                                            hx-trigger="cds-checkbox-changed"
+                                            hx-vals="js:{
+                                                isActive: event.detail.checked
+                                            }"
+                                            style="pointer-events: auto"
+                                            >Active only</cds-checkbox
+                                        >
+                                    </cds-overflow-menu-item>
+                                </cds-overflow-menu-body>
+                            </cds-overflow-menu>
                             <cds-button
                                 hx-get="/admin/connectors/create"
                                 hx-target="#modal-container"

--- a/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
+++ b/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
@@ -34,6 +34,18 @@
                 <cds-table id="profile-table">
                     <cds-table-toolbar slot="toolbar">
                         <cds-table-toolbar-content>
+                            <cds-checkbox
+                                id="active-filter-toggle"
+                                th:checked="${isActive}"
+                                hx-get="/admin/connectors"
+                                hx-target="#view-panel"
+                                hx-swap="innerHTML"
+                                hx-trigger="cds-checkbox-changed"
+                                hx-vals="js:{
+                                    isActive: event.detail.checked
+                                }"
+                                >Active only</cds-checkbox
+                            >
                             <cds-button
                                 hx-get="/admin/connectors/create"
                                 hx-target="#modal-container"
@@ -70,6 +82,12 @@
                             <cds-table-header-cell class="col-width-15">
                                 Version
                             </cds-table-header-cell>
+                            <cds-table-header-cell>
+                                Status
+                            </cds-table-header-cell>
+                            <cds-table-header-cell>
+                                Active
+                            </cds-table-header-cell>
                             <cds-table-header-cell> </cds-table-header-cell>
                         </cds-table-header-row>
                     </cds-table-head>
@@ -92,8 +110,21 @@
                             <cds-table-cell
                                 th:text="${connector.version.value}"
                             ></cds-table-cell>
+                            <cds-table-cell>
+                                <cds-tag
+                                    th:type="${connector.status.name() == 'FINAL' ? 'green' : 'cool-gray'}"
+                                    th:text="${connector.status.name()}"
+                                ></cds-tag>
+                            </cds-table-cell>
+                            <cds-table-cell>
+                                <cds-tag
+                                    th:type="${connector.isActive ? 'green' : 'cool-gray'}"
+                                    th:text="${connector.isActive ? 'Yes' : 'No'}"
+                                ></cds-tag>
+                            </cds-table-cell>
                             <cds-table-cell class="app--table-cell-actions">
                                 <cds-overflow-menu
+                                    th:if="${connector.status.name() == 'DRAFT'}"
                                     enter-delay-ms="3000"
                                     leave-delay-ms="0"
                                     close-on-activation

--- a/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
+++ b/src/main/resources/templates/fragments/internal/connector/listPageConnectors.html
@@ -148,6 +148,9 @@
                                 ></cds-tag>
                             </cds-table-cell>
                             <cds-table-cell class="app--table-cell-actions">
+                                <div
+                                    th:if="${connector.status.name() != 'DRAFT'}"
+                                ></div>
                                 <cds-overflow-menu
                                     th:if="${connector.status.name() == 'DRAFT'}"
                                     enter-delay-ms="3000"


### PR DESCRIPTION
## Summary
- **Active filter toggle**: Both ADP and Connector list tables now have an "Active only" checkbox (checked by default) that filters to active versions. Unchecking shows all versions including inactive ones. The filter state persists across search, sort, and pagination.
- **Status & Active columns**: Added Status (DRAFT/FINAL) and Active (Yes/No) columns with color-coded `cds-tag` badges to both list tables.
- **DRAFT-only deletion**: The overflow menu with the Delete action is only shown for items with DRAFT status. FINAL items cannot be deleted from the list.
- **Duplicate check fix**: `UniqueAggregatedDataProfileValidator` now uses case-sensitive `existsByName` native query instead of `findByName`.

## Test plan
- [ ] Verify ADP list loads with "Active only" checked by default, showing only active profiles
- [ ] Toggle the checkbox off and verify inactive profiles also appear
- [ ] Verify Status and Active columns display correctly with tags
- [ ] Verify the delete overflow menu only appears on DRAFT items
- [ ] Repeat above checks for the Connector list
- [ ] Verify search, sort, and pagination preserve the active filter state

🤖 Generated with [Claude Code](https://claude.com/claude-code)