### PR TITLE
fix: preserve sort order across pagination and search

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -107,7 +107,7 @@ internal class AggregatedDataProfileController(
     @GetMapping
     fun list(
         @RequestParam(required = false, defaultValue = "") query: String = "",
-        @RequestParam(required = false) isActive: Boolean? = true,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean? = true,
         @PageableDefault(size = PAGE_DEFAULT, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
@@ -140,7 +140,7 @@ internal class AggregatedDataProfileController(
     @GetMapping("/pagination")
     fun pagination(
         @RequestParam(required = false, defaultValue = "") query: String,
-        @RequestParam(required = false) isActive: Boolean? = true,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean? = true,
         @PageableDefault(size = PAGE_DEFAULT, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
     ): ModelAndView {
         val page = aggregatedDataProfileRepository.findAllBy(isActive, pageable)
@@ -162,7 +162,7 @@ internal class AggregatedDataProfileController(
     @GetMapping("/filter")
     fun filter(
         @RequestParam(required = false, defaultValue = "") query: String,
-        @RequestParam(required = false) isActive: Boolean? = true,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean? = true,
         @PageableDefault(size = PAGE_DEFAULT, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): List<ModelAndView> {

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -78,7 +78,7 @@ class ConnectorController(
     @GetMapping
     fun list(
         @RequestParam(required = false, defaultValue = "") query: String = "",
-        @RequestParam(required = false) isActive: Boolean? = true,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean? = true,
         @PageableDefault(size = PAGE_DEFAULT, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
         @RequestHeader(HomeController.HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
@@ -105,7 +105,7 @@ class ConnectorController(
     @GetMapping("/filter")
     fun filter(
         @RequestParam(required = false, defaultValue = "") query: String,
-        @RequestParam(required = false) isActive: Boolean? = true,
+        @RequestParam(required = false, defaultValue = "true") isActive: Boolean? = true,
         @PageableDefault(size = PAGE_DEFAULT, sort = ["name"], direction = Sort.Direction.ASC) pageable: Pageable,
         @RequestHeader(HomeController.HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): List<ModelAndView> {

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -40,7 +40,7 @@
                     hx-swap="outerHTML"
                     hx-push-url="true"
                     hx-vals="js:{
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                         sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
                 >
@@ -66,7 +66,7 @@
                         <cds-overflow-menu-item style="pointer-events: none">
                             <cds-checkbox
                                 id="active-filter-toggle"
-                                th:checked="${isActive != null and isActive}"
+                                th:checked="${isActive == null or isActive}"
                                 hx-get="/admin/aggregated-data-profiles/filter"
                                 hx-target="#search-results"
                                 hx-swap="outerHTML"
@@ -125,7 +125,7 @@
                         size: document.querySelector('#pagination-container').pageSize,
                         page: document.querySelector('#pagination-container').page - 1,
                         query: document.querySelector('#search-bar').value,
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true
                         }"
                 >
                     Name
@@ -159,7 +159,7 @@
                       size: document.querySelector('#pagination-container').pageSize,
                       page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                       sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -40,7 +40,8 @@
                     hx-swap="outerHTML"
                     hx-push-url="true"
                     hx-vals="js:{
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                        sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
                 >
                 </cds-table-toolbar-search>
@@ -69,12 +70,14 @@
                                 hx-get="/admin/aggregated-data-profiles/filter"
                                 hx-target="#search-results"
                                 hx-swap="outerHTML"
+                                hx-push-url="true"
                                 hx-trigger="cds-checkbox-changed"
                                 hx-vals="js:{
-                                    ...(event.detail.checked ? {isActive: true} : {}),
-                                    size: document.querySelector('#pagination-container')?.__pageSize || 10,
+                                    isActive: event.detail.checked,
+                                    size: document.querySelector('#pagination-container')?.pageSize || 10,
                                     page: 0,
-                                    query: document.querySelector('#search-bar')?.value || ''
+                                    query: document.querySelector('#search-bar')?.value || '',
+                                    sort: new URLSearchParams(window.location.search).get('sort') || ''
                                 }"
                                 style="pointer-events: auto"
                                 >Active only</cds-checkbox
@@ -115,12 +118,12 @@
                     hx-get="/admin/aggregated-data-profiles/filter"
                     hx-target="#search-results"
                     hx-swap="outerHTML"
-                    hx-push-url="false"
+                    hx-push-url="true"
                     hx-trigger="cds-table-header-cell-sort"
                     hx-vals="js:{
                         sort: 'name,' + ({ none: '', ascending: 'ASC', descending: 'DESC' }[event.detail.sortDirection] ?? ''),
-                        size: document.querySelector('#pagination-container').__pageSize,
-                        page: document.querySelector('#pagination-container').__page - 1,
+                        size: document.querySelector('#pagination-container').pageSize,
+                        page: document.querySelector('#pagination-container').page - 1,
                         query: document.querySelector('#search-bar').value,
                         ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
                         }"
@@ -153,10 +156,11 @@
         hx-swap="outerHTML"
         hx-push-url="true"
         hx-vals="js:{
-                      size: event.detail.pageSize,
-                      page: event.detail.page - 1,
+                      size: document.querySelector('#pagination-container').pageSize,
+                      page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >
         <cds-select-item value="10">10</cds-select-item>

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -34,7 +34,7 @@
                       size: document.querySelector('#pagination-container').pageSize,
                       page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                       sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -31,10 +31,11 @@
         hx-push-url="true"
         hx-on:cds-pagination-changed-current="console.log('cds-pagination-changed-current', event, this.pageSize, this.page)"
         hx-vals="js:{
-                      size: event.detail.pageSize,
-                      page: event.detail.page - 1,
+                      size: document.querySelector('#pagination-container').pageSize,
+                      page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >
         <cds-select-item value="10">10</cds-select-item>

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -40,7 +40,8 @@
                     hx-swap="outerHTML"
                     hx-push-url="true"
                     hx-vals="js:{
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                        sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
                 >
                 </cds-table-toolbar-search>
@@ -69,12 +70,14 @@
                                 hx-get="/admin/connectors/filter"
                                 hx-target="#search-results"
                                 hx-swap="outerHTML"
+                                hx-push-url="true"
                                 hx-trigger="cds-checkbox-changed"
                                 hx-vals="js:{
-                                    ...(event.detail.checked ? {isActive: true} : {}),
-                                    size: document.querySelector('#pagination-container')?.__pageSize || 10,
+                                    isActive: event.detail.checked,
+                                    size: document.querySelector('#pagination-container')?.pageSize || 10,
                                     page: 0,
-                                    query: document.querySelector('#search-bar')?.value || ''
+                                    query: document.querySelector('#search-bar')?.value || '',
+                                    sort: new URLSearchParams(window.location.search).get('sort') || ''
                                 }"
                                 style="pointer-events: auto"
                                 >Active only</cds-checkbox
@@ -117,12 +120,12 @@
                     hx-get="/admin/connectors/filter"
                     hx-target="#search-results"
                     hx-swap="outerHTML"
-                    hx-push-url="false"
+                    hx-push-url="true"
                     hx-trigger="cds-table-header-cell-sort"
                     hx-vals="js:{
                         sort: 'name,' + ({ none: '', ascending: 'ASC', descending: 'DESC' }[event.detail.sortDirection] ?? ''),
-                        size: document.querySelector('#pagination-container').__pageSize,
-                        page: document.querySelector('#pagination-container').__page - 1,
+                        size: document.querySelector('#pagination-container').pageSize,
+                        page: document.querySelector('#pagination-container').page - 1,
                         query: document.querySelector('#search-bar').value,
                         ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
                         }"
@@ -159,10 +162,11 @@
         hx-swap="outerHTML"
         hx-push-url="true"
         hx-vals="js:{
-                      size: event.detail.pageSize,
-                      page: event.detail.page - 1,
+                      size: document.querySelector('#pagination-container').pageSize,
+                      page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >
         <cds-select-item value="10">10</cds-select-item>

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -40,7 +40,7 @@
                     hx-swap="outerHTML"
                     hx-push-url="true"
                     hx-vals="js:{
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                         sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
                 >
@@ -66,7 +66,7 @@
                         <cds-overflow-menu-item style="pointer-events: none">
                             <cds-checkbox
                                 id="active-filter-toggle"
-                                th:checked="${isActive != null and isActive}"
+                                th:checked="${isActive == null or isActive}"
                                 hx-get="/admin/connectors/filter"
                                 hx-target="#search-results"
                                 hx-swap="outerHTML"
@@ -127,7 +127,7 @@
                         size: document.querySelector('#pagination-container').pageSize,
                         page: document.querySelector('#pagination-container').page - 1,
                         query: document.querySelector('#search-bar').value,
-                        ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                        isActive: document.querySelector('#active-filter-toggle')?.checked ?? true
                         }"
                 >
                     Name
@@ -165,7 +165,7 @@
                       size: document.querySelector('#pagination-container').pageSize,
                       page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                       sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >

--- a/src/main/resources/templates/fragments/internal/connector/pagination.html
+++ b/src/main/resources/templates/fragments/internal/connector/pagination.html
@@ -29,10 +29,11 @@
         hx-swap="outerHTML"
         hx-push-url="true"
         hx-vals="js:{
-                      size: event.detail.pageSize,
-                      page: event.detail.page - 1,
+                      size: document.querySelector('#pagination-container').pageSize,
+                      page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {})
+                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >
         <cds-select-item value="10">10</cds-select-item>

--- a/src/main/resources/templates/fragments/internal/connector/pagination.html
+++ b/src/main/resources/templates/fragments/internal/connector/pagination.html
@@ -32,7 +32,7 @@
                       size: document.querySelector('#pagination-container').pageSize,
                       page: document.querySelector('#pagination-container').page - 1,
                       query: document.querySelector('#search-bar').value,
-                      ...(document.querySelector('#active-filter-toggle')?.checked ? {isActive: true} : {}),
+                      isActive: document.querySelector('#active-filter-toggle')?.checked ?? true,
                       sort: new URLSearchParams(window.location.search).get('sort') || ''
                     }"
     >


### PR DESCRIPTION
## Summary
- **Sort order preserved**: All HTMX controls (pagination, search bar, active filter toggle) now read the `sort` param from the URL and include it in every request, so sort order is no longer lost when changing pages or filtering
- **Sort headers push URL**: Changed `hx-push-url` from `false` to `true` on sort headers so the URL becomes the single source of truth for sort state
- **Fixed broken Lit property references**: Replaced `__pageSize`/`__page` (Lit 2 internal names) with public `pageSize`/`page` properties across all templates
- **isActive filter pushes URL**: Added `hx-push-url="true"` to the active filter toggle and sends `isActive` explicitly on both check and uncheck

## Test plan
- [ ] Load ADP/Connector list with default sort (name ASC)
- [ ] Click Name header to sort DESC → verify URL updates with `sort=name,DESC`
- [ ] Navigate to page 2 → verify sort remains DESC in URL and results
- [ ] Change page size → verify sort is maintained
- [ ] Search/filter → verify sort is maintained with search results
- [ ] Toggle "Active only" filter → verify URL updates with `isActive` param
- [ ] Uncheck "Active only" → verify `isActive=false` appears in URL and all items shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)