### PR TITLE
fix: render tool column correctly in ADP and Connector lists (#253)

### DIFF
--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -416,12 +416,11 @@ cds-table-row.not-clickable {
 }
 
 cds-table-row > .app--table-cell-actions {
-    display: flex;
-    flex-flow: row;
-    justify-content: flex-end;
-    padding: 0;
+    line-height: 3rem;
+    padding-inline-end: 0;
 
     cds-overflow-menu {
+        float: right;
         block-size: 3rem;
         inline-size: 3rem;
     }

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
@@ -47,8 +47,6 @@
             <cds-table-cell></cds-table-cell>
             <cds-table-cell></cds-table-cell>
             <cds-table-cell></cds-table-cell>
-            <cds-table-cell></cds-table-cell>
-            <cds-table-cell></cds-table-cell>
         </cds-table-row>
         <cds-table-row
             th:each="aggregatedDataProfile : ${aggregatedDataProfiles}"
@@ -69,16 +67,13 @@
                     th:text="${aggregatedDataProfile.status}"
                 ></cds-tag>
             </cds-table-cell>
-            <cds-table-cell>
+            <cds-table-cell class="app--table-cell-actions">
                 <cds-tag
                     th:type="${aggregatedDataProfile.active ? 'green' : 'cool-gray'}"
                     th:text="${aggregatedDataProfile.active ? 'Yes' : 'No'}"
                 ></cds-tag>
-            </cds-table-cell>
-            <cds-table-cell class="app--table-cell-actions">
-                <div th:if="${aggregatedDataProfile.status != 'DRAFT'}"></div>
                 <cds-overflow-menu
-                    th:if="${aggregatedDataProfile.status == 'DRAFT'}"
+                    th:disabled="${aggregatedDataProfile.status != 'DRAFT'}"
                     enter-delay-ms="3000"
                     leave-delay-ms="0"
                     close-on-activation
@@ -103,6 +98,7 @@
                     <span slot="tooltip-content"> Options </span>
                     <cds-overflow-menu-body flipped="">
                         <cds-overflow-menu-item
+                            th:if="${aggregatedDataProfile.status == 'DRAFT'}"
                             hx-confirm="Are you sure you want to delete this Aggregated Data Profile?"
                             th:hx-delete="@{|/admin/aggregated-data-profiles/${aggregatedDataProfile.id}|}"
                             hx-swap="outerHTML"

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -133,7 +133,6 @@
                 <cds-table-header-cell>Version</cds-table-header-cell>
                 <cds-table-header-cell>Status</cds-table-header-cell>
                 <cds-table-header-cell>Active</cds-table-header-cell>
-                <cds-table-header-cell></cds-table-header-cell>
             </cds-table-header-row>
         </cds-table-head>
 

--- a/src/main/resources/templates/fragments/internal/connector/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/connector/filter-results.html
@@ -25,7 +25,6 @@
             <cds-table-cell></cds-table-cell>
             <cds-table-cell></cds-table-cell>
             <cds-table-cell></cds-table-cell>
-            <cds-table-cell></cds-table-cell>
         </cds-table-row>
         <cds-table-row
             th:each="connector : ${connectors}"
@@ -45,16 +44,13 @@
                     th:text="${connector.status}"
                 ></cds-tag>
             </cds-table-cell>
-            <cds-table-cell>
+            <cds-table-cell class="app--table-cell-actions">
                 <cds-tag
                     th:type="${connector.active ? 'green' : 'cool-gray'}"
                     th:text="${connector.active ? 'Yes' : 'No'}"
                 ></cds-tag>
-            </cds-table-cell>
-            <cds-table-cell class="app--table-cell-actions">
-                <div th:if="${connector.status != 'DRAFT'}"></div>
                 <cds-overflow-menu
-                    th:if="${connector.status == 'DRAFT'}"
+                    th:disabled="${connector.status != 'DRAFT'}"
                     enter-delay-ms="3000"
                     leave-delay-ms="0"
                     close-on-activation
@@ -79,6 +75,7 @@
                     <span slot="tooltip-content"> Options </span>
                     <cds-overflow-menu-body flipped="">
                         <cds-overflow-menu-item
+                            th:if="${connector.status == 'DRAFT'}"
                             hx-confirm="Are you sure you want to delete this connector?"
                             th:hx-delete="@{|/admin/connectors/${connector.id}|}"
                             hx-swap="outerHTML"

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -140,7 +140,6 @@
                 </cds-table-header-cell>
                 <cds-table-header-cell> Status </cds-table-header-cell>
                 <cds-table-header-cell> Active </cds-table-header-cell>
-                <cds-table-header-cell> </cds-table-header-cell>
             </cds-table-header-row>
         </cds-table-head>
 


### PR DESCRIPTION
## Summary
- Fixes the tool/actions column rendering in both ADP and Connector list tables
- Replaces the empty `<div>` fallback for FINAL items with a disabled `<cds-overflow-menu>`, ensuring consistent column layout regardless of status
- Delete menu item is conditionally rendered only for DRAFT items

Closes Integraal-Klant-en-Objectbeeld/iko-issues#253

## Test plan
- [ ] Verify ADP list renders overflow menu icon (disabled) for FINAL items
- [ ] Verify Connector list renders overflow menu icon (disabled) for FINAL items
- [ ] Verify DRAFT items still show clickable overflow menu with Delete option
- [ ] Verify table column alignment is consistent across DRAFT and FINAL rows