### PR TITLE
fix: rename search placeholder to clarify it filters on name (#256)

### DIFF
--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -28,7 +28,7 @@
             <cds-table-toolbar-content>
                 <cds-table-toolbar-search
                     id="search-bar"
-                    placeholder="Type to search..."
+                    placeholder="Type to filter on name..."
                     th:value="${query}"
                     th:expanded="${query} ?: 'true'"
                     name="query"

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -28,7 +28,7 @@
             <cds-table-toolbar-content>
                 <cds-table-toolbar-search
                     id="search-bar"
-                    placeholder="Type to search..."
+                    placeholder="Type to filter on name..."
                     th:value="${query}"
                     th:expanded="${query} ?: 'true'"
                     name="query"


### PR DESCRIPTION
## Summary
- Renamed placeholder text from "Type to search..." to "Type to filter on name..." in both the ADP and Connector list views, since the search only filters by name.

Closes Integraal-Klant-en-Objectbeeld/iko-issues#256

🤖 Generated with [Claude Code](https://claude.com/claude-code)