### PR TITLE
fix: add finalize confirmation modal for connectors and fix pagination page size

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -832,6 +832,18 @@ class ConnectorController(
         }
     }
 
+    @PostMapping("/{id}/finalize/preview")
+    fun finalizePreview(
+        @PathVariable id: UUID,
+    ): ModelAndView {
+        val connector = connectorRepository.findById(id)
+            .orElseThrow { NoSuchElementException("Connector not found: $id") }
+        return ModelAndView("fragments/internal/versioning/finalize-connector-modal")
+            .addObject("connectorId", connector.id)
+            .addObject("connectorName", connector.name)
+            .addObject("connectorVersion", connector.version.value)
+    }
+
     @PostMapping("/{id}/finalize")
     fun finalizeConnector(
         @PathVariable id: UUID,

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -24,7 +24,7 @@
                                   total-items=${page.totalElements},
                                   page-size=${page.size},
                                   disabled=${!creationAllowed} ? 'disabled' : null"
-        hx-trigger="cds-pagination-changed-current from:closest cds-pagination"
+        hx-trigger="cds-pagination-changed-current from:closest cds-pagination, cds-page-sizes-select-changed from:closest cds-pagination"
         hx-get="/admin/aggregated-data-profiles/filter"
         hx-target="#search-results"
         hx-swap="outerHTML"

--- a/src/main/resources/templates/fragments/internal/connector/pagination.html
+++ b/src/main/resources/templates/fragments/internal/connector/pagination.html
@@ -23,7 +23,7 @@
                                   totalPages=${page.totalPages},
                                   total-items=${page.totalElements},
                                   page-size=${page.size}"
-        hx-trigger="cds-pagination-changed-current from:closest cds-pagination"
+        hx-trigger="cds-pagination-changed-current from:closest cds-pagination, cds-page-sizes-select-changed from:closest cds-pagination"
         hx-get="/admin/connectors/filter"
         hx-target="#search-results"
         hx-swap="outerHTML"

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
@@ -1,0 +1,49 @@
+<!--
+ Copyright (C) 2026 Ritense BV, the Netherlands.
+
+ Licensed under EUPL, Version 1.2 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+<cds-modal
+    id="active-modal"
+    prevent-close-on-click-outside="true"
+    open="true"
+    size="md"
+>
+    <cds-modal-header>
+        <cds-modal-close-button></cds-modal-close-button>
+        <cds-modal-heading
+            >Finalize
+            <span th:text="|${connectorName} v${connectorVersion}|"></span
+        ></cds-modal-heading>
+    </cds-modal-header>
+    <cds-modal-body>
+        <p>
+            This will make the connector immutable. Are you sure you want to
+            finalize this connector?
+        </p>
+    </cds-modal-body>
+    <cds-modal-footer>
+        <cds-modal-footer-button data-modal-close="" kind="secondary"
+            >Cancel</cds-modal-footer-button
+        >
+        <cds-modal-footer-button
+            th:hx-post="@{|/admin/connectors/${connectorId}/finalize|}"
+            hx-target="#view-panel"
+            hx-swap="innerHTML"
+            hx-on::after-request="document.getElementById('active-modal')?.removeAttribute('open')"
+            kind="danger"
+            >Finalize</cds-modal-footer-button
+        >
+    </cds-modal-footer>
+</cds-modal>

--- a/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
+++ b/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
@@ -82,8 +82,8 @@
                                 <cds-menu-item
                                     th:if="${status.name() == 'DRAFT'}"
                                     label="Finalize"
-                                    th:hx-post="@{|/admin/${entityType}s/${entityId}/${entityType == 'aggregated-data-profile' ? 'finalize/preview' : 'finalize'}|}"
-                                    th:hx-target="${entityType == 'aggregated-data-profile' ? '#modal-container' : '#view-panel'}"
+                                    th:hx-post="@{|/admin/${entityType}s/${entityId}/finalize/preview|}"
+                                    hx-target="#modal-container"
                                     hx-swap="innerHTML"
                                 ></cds-menu-item>
                                 <cds-menu-item


### PR DESCRIPTION
## Summary
- Add a confirmation popup when finalizing connectors (simple confirm dialog without reference/impact info), matching the ADP finalize flow
- Fix items-per-page selector not triggering a reload on both ADP and Connector list pages by adding `cds-page-sizes-select-changed` to the HTMX trigger

## Changes
- **`ConnectorController.kt`** — Added `POST /{id}/finalize/preview` endpoint that renders the confirmation modal
- **`finalize-connector-modal.html`** — New simple confirmation modal for connector finalization
- **`page-header-versioned.html`** — Both entity types now use `finalize/preview` → `#modal-container` flow
- **`pagination.html` (ADP + Connector)** — Added `cds-page-sizes-select-changed` event to `hx-trigger`

Closes Integraal-Klant-en-Objectbeeld/iko-issues#258

## Test plan
- [ ] Navigate to a DRAFT connector → Version menu → Finalize → confirm modal appears
- [ ] Cancel dismisses modal, Finalize button finalizes the connector
- [ ] ADP finalize preview still works as before
- [ ] Change items per page on connector list → list reloads with correct page size
- [ ] Change items per page on ADP list → list reloads with correct page size

🤖 Generated with [Claude Code](https://claude.com/claude-code)