### PR TITLE
fix: make finalized connector instances readonly (#266)

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -362,6 +362,7 @@ class ConnectorController(
     ): ModelAndView {
         val connector = connectorRepository.findById(id)
             .orElseThrow { NoSuchElementException("Connector not found") }
+        connector.ensureDraft()
         val connectorInstance = connectorInstanceRepository.findById(instanceId)
             .orElseThrow { NoSuchElementException("Connector instance not found") }
 

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
@@ -80,6 +80,7 @@
                                                 th:value="${connectorInstance.name}"
                                                 th:attr="invalid=${errors?.getFieldError('name') != null} ? 'true' : null,
                                                     invalid-text=${errors?.getFieldError('name')?.defaultMessage}"
+                                                th:readonly="${connector.status.name() != 'DRAFT'}"
                                                 required=""
                                                 label="Name"
                                             ></cds-text-input>
@@ -88,16 +89,18 @@
                                                 th:value="${connectorInstance.tag}"
                                                 th:attr="invalid=${errors?.getFieldError('reference') != null} ? 'true' : null,
                                                     invalid-text=${errors?.getFieldError('reference')?.defaultMessage}"
+                                                th:readonly="${connector.status.name() != 'DRAFT'}"
                                                 required=""
                                                 label="Reference"
                                             ></cds-text-input>
                                             <cds-text-input
                                                 name="apiSpecificationUrl"
                                                 th:value="${connectorInstance.apiSpecificationUrl}"
+                                                th:readonly="${connector.status.name() != 'DRAFT'}"
                                                 label="API Specification URL"
                                                 helper-text="Optional. URL to the OpenAPI specification."
                                             ></cds-text-input>
-                                            <cds-form-item class="form-actions">
+                                            <cds-form-item class="form-actions" th:if="${connector.status.name() == 'DRAFT'}">
                                                 <cds-button
                                                     id="instance-save-btn"
                                                     th:hx-put="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}|}"
@@ -131,6 +134,7 @@
                                         th:hx-get="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}/config|}"
                                         hx-target="#modal-container"
                                         kind="primary"
+                                        th:disabled="${connector.status.name() != 'DRAFT'}"
                                     >
                                         Add config
                                         <svg
@@ -214,6 +218,7 @@
                                     </cds-table-cell>
                                     <cds-table-cell
                                         class="app--table-cell-actions"
+                                        th:if="${connector.status.name() == 'DRAFT'}"
                                     >
                                         <cds-overflow-menu
                                             enter-delay-ms="3000"
@@ -284,6 +289,7 @@
                                         th:hx-get="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}/roles|}"
                                         hx-target="#modal-container"
                                         kind="primary"
+                                        th:disabled="${connector.status.name() != 'DRAFT'}"
                                     >
                                         Add role
                                         <svg
@@ -330,6 +336,7 @@
                                     ></cds-table-cell>
                                     <cds-table-cell
                                         class="app--table-cell-actions"
+                                        th:if="${connector.status.name() == 'DRAFT'}"
                                     >
                                         <cds-overflow-menu
                                             enter-delay-ms="3000"

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
@@ -100,7 +100,10 @@
                                                 label="API Specification URL"
                                                 helper-text="Optional. URL to the OpenAPI specification."
                                             ></cds-text-input>
-                                            <cds-form-item class="form-actions" th:if="${connector.status.name() == 'DRAFT'}">
+                                            <cds-form-item
+                                                class="form-actions"
+                                                th:if="${connector.status.name() == 'DRAFT'}"
+                                            >
                                                 <cds-button
                                                     id="instance-save-btn"
                                                     th:hx-put="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}|}"


### PR DESCRIPTION
## Summary
- Add missing `ensureDraft()` guard to the `editConnectorInstance` PUT endpoint, preventing backend edits to finalized connector instances
- Make all text inputs readonly on the connector instance detail page when the parent connector is FINAL
- Hide the Save button and all delete/add action buttons (config, roles) when the connector is FINAL

Closes Integraal-Klant-en-Objectbeeld/iko-issues#266

## Test plan
- [ ] Open a FINAL connector's instance detail page — verify inputs are readonly and Save button is hidden
- [ ] Verify "Add config" and "Add role" buttons are disabled
- [ ] Verify config/role delete overflow menus are hidden
- [ ] Confirm DRAFT connector instances remain fully editable