### PR TITLE
fix: filter relation connector endpoints by selected instance on initial load (#261)

### DIFF
--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
@@ -23,5 +23,6 @@ import java.util.UUID
 
 interface ConnectorEndpointRepository : JpaRepository<ConnectorEndpoint, UUID> {
     fun findByConnector(connector: Connector): List<ConnectorEndpoint>
+    fun findByConnectorOrderByNameAsc(connector: Connector): List<ConnectorEndpoint>
     fun findByConnectorIdAndOperation(connectorId: UUID, operation: String): ConnectorEndpoint?
 }

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -353,10 +353,11 @@ internal class AggregatedDataProfileController(
     ): ModelAndView {
         val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
         val sources = sources(aggregatedDataProfile)
+        val connectorInstances = connectorInstanceRepository.findAllByOrderByNameAsc()
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/add").apply {
             addObject("aggregatedDataProfileId", id)
-            addObject("connectorInstances", connectorInstanceRepository.findAllByOrderByNameAsc())
-            addObject("connectorEndpoints", connectorEndpointRepository.findAll())
+            addObject("connectorInstances", connectorInstances)
+            addObject("connectorEndpoints", connectorEndpointRepository.findByConnector(connectorInstances.first().connector))
             addObject("sources", sources)
             addObject("parentId", sourceId)
         }

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -357,7 +357,7 @@ internal class AggregatedDataProfileController(
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/add").apply {
             addObject("aggregatedDataProfileId", id)
             addObject("connectorInstances", connectorInstances)
-            addObject("connectorEndpoints", connectorEndpointRepository.findByConnector(connectorInstances.first().connector))
+            addObject("connectorEndpoints", connectorEndpointRepository.findByConnectorOrderByNameAsc(connectorInstances.first().connector))
             addObject("sources", sources)
             addObject("parentId", sourceId)
         }

--- a/src/main/resources/templates/fragments/internal/relation/add.html
+++ b/src/main/resources/templates/fragments/internal/relation/add.html
@@ -57,7 +57,7 @@
                     size="lg"
                     name="connectorInstanceId"
                     th:value="${form != null ? form.connectorInstanceId : connectorInstances.first.id}"
-                    hx-get="/admin/aggregated-data-profiles/create/endpoints"
+                    hx-get="/admin/aggregated-data-profiles/relations/add/endpoints"
                     hx-trigger="cds-select-selected"
                     hx-target="#formRelationEndpoints"
                     th:attr="invalid=${errors?.getFieldError('connectorInstanceId') != null} ? 'true' : null,


### PR DESCRIPTION
## Summary
- **Controller**: `relationCreate()` used `connectorEndpointRepository.findAll()` showing all endpoints across all connectors. Changed to `findByConnectorOrderByNameAsc(connectorInstances.first().connector)` to only show endpoints for the default-selected connector instance, ordered by name.
- **Repository**: Added `findByConnectorOrderByNameAsc` query method to `ConnectorEndpointRepository`.
- **Template**: `add.html` HTMX `hx-get` pointed to `/admin/aggregated-data-profiles/create/endpoints` (ADP form handler, wrong fragment). Fixed to `/admin/aggregated-data-profiles/relations/add/endpoints` (relation-specific handler).

Closes Integraal-Klant-en-Objectbeeld/iko-issues#261

## Test plan
- [ ] Open an ADP, click "Add child" to create a new relation
- [ ] Verify the endpoint dropdown only shows endpoints for the first connector instance, sorted by name
- [ ] Change the connector instance dropdown and verify endpoints update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)