### PR TITLE
fix: upgrade Spring Boot to 3.5.13 (CVE-2026-33871)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.2.0"
-springBoot = "3.5.9"
+springBoot = "3.5.13"
 springDependencyManagement = "1.1.7"
 dockerCompose = "0.17.20"
 dotenv = "4.0.0"


### PR DESCRIPTION
## Summary
- Upgrades Spring Boot from 3.5.9 → 3.5.13 to resolve CVE-2026-33871 (Netty HTTP/2 CONTINUATION frame flood DoS, CVSS 8.7)
- Netty is upgraded transitively from 4.1.130.Final → 4.1.132.Final
- Also picks up the fix for CVE-2026-33870 (HTTP/1.1 request smuggling)

## Test plan
- [x] Unit tests pass (`./gradlew test`)
- [x] Verified Netty resolves to 4.1.132.Final via `./gradlew dependencies`
- [x] Integration tests

Closes Integraal-Klant-en-Objectbeeld/iko-issues#268

🤖 Generated with [Claude Code](https://claude.com/claude-code)