### PR TITLE
fix: make ADP form fields readonly when status is FINAL

### DIFF
--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
@@ -111,6 +111,14 @@ class AggregatedDataProfile(
         )
     }
 
+    fun updateRelationCacheSettings(relationId: UUID, enabled: Boolean, timeToLive: Int) {
+        val relation = this.relations.first { it.id == relationId }
+        relation.relationCacheSettings = RelationCacheSettings(
+            enabled = enabled,
+            timeToLive = timeToLive,
+        )
+    }
+
     fun addRelation(form: AddRelationForm) {
         ensureDraft()
         this.relations.add(

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
@@ -105,7 +105,6 @@ class AggregatedDataProfile(
     }
 
     fun updateCacheSettings(enabled: Boolean, timeToLive: Int) {
-        ensureDraft()
         this.aggregatedDataProfileCacheSetting = AggregatedDataProfileCacheSetting(
             enabled = enabled,
             timeToLive = timeToLive,

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -34,6 +34,7 @@ import com.ritense.iko.mvc.model.AggregatedDataProfileEditForm
 import com.ritense.iko.mvc.model.CreateVersionForm
 import com.ritense.iko.mvc.model.EditRelationForm
 import com.ritense.iko.mvc.model.Relation
+import com.ritense.iko.mvc.model.RelationCacheForm
 import com.ritense.iko.mvc.model.Source
 import com.ritense.iko.security.SecurityContextHelper
 import jakarta.servlet.http.HttpServletResponse
@@ -462,6 +463,52 @@ internal class AggregatedDataProfileController(
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
         httpServletResponse.setHeader("HX-Reswap", "innerHTML")
         return details(id, true)
+    }
+
+    @PutMapping(
+        path = ["/{id}/relation/{relationId}/cache"],
+        consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE],
+    )
+    fun editRelationCache(
+        @PathVariable id: UUID,
+        @PathVariable relationId: UUID,
+        @Valid @ModelAttribute form: RelationCacheForm,
+        bindingResult: BindingResult,
+    ): ModelAndView {
+        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val relation = aggregatedDataProfile.relations.first { it.id == relationId }
+        val isCached = cacheService.isCached(relation.id.toString())
+        val connectorInstance = connectorInstanceRepository.findById(relation.connectorInstanceId).orElseThrow()
+        val sources = sources(aggregatedDataProfile).apply { this.removeIf { it.id == relationId.toString() } }
+        if (bindingResult.hasErrors()) {
+            return ModelAndView("$BASE_FRAGMENT_RELATION/edit :: relation-edit").apply {
+                addObject("errors", bindingResult)
+                addObject("form", EditRelationForm.from(relation))
+                addObject("aggregatedDataProfile", aggregatedDataProfile)
+                addObject("sources", sources)
+                addObject("connectorInstances", connectorInstanceRepository.findAllByOrderByNameAsc())
+                addObject("connectorEndpoints", connectorEndpointRepository.findByConnector(connectorInstance.connector))
+                addObject("isCached", isCached)
+            }
+        }
+        aggregatedDataProfile.updateRelationCacheSettings(
+            relationId = relationId,
+            enabled = form.cacheEnabled,
+            timeToLive = form.cacheTimeToLive,
+        )
+        aggregatedDataProfileRepository.save(aggregatedDataProfile)
+        if (aggregatedDataProfile.isActive) {
+            aggregatedDataProfileService.reloadRoute(aggregatedDataProfile)
+        }
+        val updatedRelation = aggregatedDataProfile.relations.first { it.id == relationId }
+        return ModelAndView("$BASE_FRAGMENT_RELATION/edit :: relation-edit").apply {
+            addObject("form", EditRelationForm.from(updatedRelation))
+            addObject("aggregatedDataProfile", aggregatedDataProfile)
+            addObject("sources", sources)
+            addObject("connectorInstances", connectorInstanceRepository.findAllByOrderByNameAsc())
+            addObject("connectorEndpoints", connectorEndpointRepository.findByConnector(connectorInstance.connector))
+            addObject("isCached", isCached)
+        }
     }
 
     @DeleteMapping("/{id}/relation/{relationId}/cache")

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -380,6 +380,7 @@ internal class AggregatedDataProfileController(
             addObject("connectorEndpoints", connectorEndpointRepository.findByConnector(connector.connector))
             addObject("form", EditRelationForm.from(relation))
             addObject("isCached", isCached)
+            addObject("aggregatedDataProfile", aggregatedDataProfile)
         }
         return modelAndView
     }

--- a/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Ritense BV, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.mvc.model
+
+import com.ritense.iko.aggregateddataprofile.domain.Relation
+import jakarta.validation.constraints.Min
+import java.util.UUID
+
+data class RelationCacheForm(
+    val aggregatedDataProfileId: UUID,
+    val id: UUID,
+    val cacheEnabled: Boolean,
+    @field:Min(value = 0)
+    val cacheTimeToLive: Int,
+) {
+    companion object {
+        fun from(relation: Relation) = RelationCacheForm(
+            aggregatedDataProfileId = relation.aggregatedDataProfile.id,
+            id = relation.id,
+            cacheEnabled = relation.relationCacheSettings.enabled,
+            cacheTimeToLive = relation.relationCacheSettings.timeToLive,
+        )
+    }
+}

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
@@ -31,7 +31,6 @@
                             label-text="Cache enabled"
                             aria-labelledby="cacheEnabled-label"
                             hx-on:cds-toggle-changed="document.querySelector('#adpCacheEnabledHidden').value = this.checked;"
-                            th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                             th:attr="invalid=${errors?.getFieldError('cacheEnabled') != null} ? 'true' : null,
                                              invalid-text=${errors?.getFieldError('cacheEnabled')?.defaultMessage},
                                              checked=${cacheForm?.cacheEnabled}"
@@ -56,7 +55,6 @@
                             label="Time to live"
                             helper-text="Milliseconds"
                             style="width: 200px"
-                            th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                             th:attr="invalid=${errors?.getFieldError('cacheTimeToLive') != null} ? 'true' : null,
                                              invalid-text=${errors?.getFieldError('cacheTimeToLive')?.defaultMessage},
                                              value=${cacheForm?.cacheTimeToLive}"
@@ -86,7 +84,6 @@
                             hx-swap="outerHTML"
                             hx-include="#cache-form *"
                             hx-on::before-swap="if (event.detail.isError) { event.detail.shouldSwap = true; event.detail.isError = false; }"
-                            th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                         >
                             Save
                         </cds-button>

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
@@ -250,6 +250,7 @@
                                             <cds-button
                                                 type="submit"
                                                 id="profile-save-btn"
+                                                th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                                                 hx-on:click="document.getElementById('profile-edit-form')?.requestSubmit()"
                                             >
                                                 Save

--- a/src/main/resources/templates/fragments/internal/relation/cache.html
+++ b/src/main/resources/templates/fragments/internal/relation/cache.html
@@ -1,0 +1,93 @@
+<!--
+ Copyright (C) 2026 Ritense BV, the Netherlands.
+
+ Licensed under EUPL, Version 1.2 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" basis,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ -->
+
+<cds-form
+    th:fragment="relation-cache"
+    id="relation-cache-form"
+    class="cds-theme-zone-white"
+    data-carbon-theme="white"
+>
+    <div class="form-column">
+        <div
+            class="form-row"
+            style="
+                flex-direction: row;
+                align-items: center;
+                justify-content: space-between;
+            "
+        >
+            <cds-toggle
+                id="cacheEnabledToggle"
+                name="cacheEnabledToggle"
+                label-text="Cache enabled"
+                aria-labelledby="cacheEnabled-label"
+                hx-on:cds-toggle-changed="document.querySelector('#relationCacheEnabledHidden').value = this.checked;"
+                th:attr="invalid=${errors?.getFieldError('cacheEnabled') != null} ? 'true' : null,
+                             invalid-text=${errors?.getFieldError('cacheEnabled')?.defaultMessage},
+                             checked=${form?.cacheEnabled}"
+            >
+            </cds-toggle>
+            <input
+                type="hidden"
+                name="cacheEnabled"
+                id="relationCacheEnabledHidden"
+                th:value="${form?.cacheEnabled}"
+            />
+            <cds-number-input
+                id="cacheTimeToLive"
+                name="cacheTimeToLive"
+                required="true"
+                value="5000"
+                min="0"
+                step="1000"
+                max="31536000000"
+                label="Time to live"
+                helper-text="Milliseconds"
+                style="width: 300px"
+                th:attr="invalid=${errors?.getFieldError('cacheTimeToLive') != null} ? 'true' : null,
+                                   invalid-text=${errors?.getFieldError('cacheTimeToLive')?.defaultMessage},
+                                   value=${form?.cacheTimeToLive}"
+            >
+            </cds-number-input>
+            <cds-button
+                kind="danger-tertiary"
+                size="sm"
+                hx-confirm="Are you sure?"
+                th:attr="hx-delete=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'},
+                             disabled=${!isCached}"
+            >
+                Clear cache
+            </cds-button>
+        </div>
+        <input
+            type="hidden"
+            name="aggregatedDataProfileId"
+            th:value="${form.aggregatedDataProfileId}"
+        />
+        <input type="hidden" name="id" th:value="${form.id}" />
+        <div class="relation-button-bar">
+            <cds-button
+                th:attr="hx-put=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'}"
+                hx-target="#relation-edit"
+                hx-swap="innerHTML"
+                hx-include="#relation-cache-form *"
+                hx-on::before-swap="if (event.detail.isError) { event.detail.shouldSwap = true; event.detail.isError = false; }"
+            >
+                Save cache
+            </cds-button>
+        </div>
+    </div>
+</cds-form>

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -296,82 +296,9 @@
     </cds-form>
 
     <!-- Relation cache settings (separate form, always editable) -->
-    <cds-form
-        id="relation-cache-form"
-        class="cds-theme-zone-white"
-        data-carbon-theme="white"
-    >
-        <div class="form-column">
-            <div
-                class="form-row"
-                style="
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: space-between;
-                "
-            >
-                <cds-toggle
-                    id="cacheEnabledToggle"
-                    name="cacheEnabledToggle"
-                    label-text="Cache enabled"
-                    aria-labelledby="cacheEnabled-label"
-                    hx-on:cds-toggle-changed="document.querySelector('#relationCacheEnabledHidden').value = this.checked;"
-                    th:attr="invalid=${errors?.getFieldError('cacheEnabled') != null} ? 'true' : null,
-                                 invalid-text=${errors?.getFieldError('cacheEnabled')?.defaultMessage},
-                                 checked=${form?.cacheEnabled}"
-                >
-                </cds-toggle>
-                <input
-                    type="hidden"
-                    name="cacheEnabled"
-                    id="relationCacheEnabledHidden"
-                    th:value="${form?.cacheEnabled}"
-                />
-                <cds-number-input
-                    id="cacheTimeToLive"
-                    name="cacheTimeToLive"
-                    required="true"
-                    value="5000"
-                    min="0"
-                    step="1000"
-                    max="31536000000"
-                    label="Time to live"
-                    helper-text="Milliseconds"
-                    style="width: 300px"
-                    th:attr="invalid=${errors?.getFieldError('cacheTimeToLive') != null} ? 'true' : null,
-                                       invalid-text=${errors?.getFieldError('cacheTimeToLive')?.defaultMessage},
-                                       value=${form?.cacheTimeToLive}"
-                >
-                </cds-number-input>
-                <cds-button
-                    kind="danger-tertiary"
-                    size="sm"
-                    hx-confirm="Are you sure?"
-                    th:attr="hx-delete=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'},
-                                 disabled=${!isCached}"
-                >
-                    Clear cache
-                </cds-button>
-            </div>
-            <input
-                type="hidden"
-                name="aggregatedDataProfileId"
-                th:value="${form.aggregatedDataProfileId}"
-            />
-            <input type="hidden" name="id" th:value="${form.id}" />
-            <div class="relation-button-bar">
-                <cds-button
-                    th:attr="hx-put=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'}"
-                    hx-target="#relation-edit"
-                    hx-swap="innerHTML"
-                    hx-include="#relation-cache-form *"
-                    hx-on::before-swap="if (event.detail.isError) { event.detail.shouldSwap = true; event.detail.isError = false; }"
-                >
-                    Save cache
-                </cds-button>
-            </div>
-        </div>
-    </cds-form>
+    <div
+        th:replace="~{fragments/internal/relation/cache :: relation-cache}"
+    ></div>
 </div>
 <span
     id="selected-relation-name"

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -218,65 +218,22 @@
                 </div>
             </cds-form-item>
 
-            <!-- Cache setting -->
-            <div
-                class="form-row"
-                style="
-                    flex-direction: row;
-                    align-items: center;
-                    justify-content: space-between;
-                "
-            >
-                <cds-toggle
-                    id="cacheEnabledToggle"
-                    name="cacheEnabledToggle"
-                    label-text="Cache enabled"
-                    aria-labelledby="cacheEnabled-label"
-                    hx-on:cds-toggle-changed="document.querySelector('#relationCacheEnabledHidden').value = this.checked;"
-                    th:attr="invalid=${errors?.getFieldError('cacheEnabled') != null} ? 'true' : null,
-                                 invalid-text=${errors?.getFieldError('cacheEnabled')?.defaultMessage},
-                                 checked=${form?.cacheEnabled}"
-                >
-                </cds-toggle>
-                <input
-                    type="hidden"
-                    name="cacheEnabled"
-                    id="relationCacheEnabledHidden"
-                    th:value="${form?.cacheEnabled}"
-                />
-                <cds-number-input
-                    id="cacheTimeToLive"
-                    name="cacheTimeToLive"
-                    required="true"
-                    value="5000"
-                    min="0"
-                    step="1000"
-                    max="31536000000"
-                    label="Time to live"
-                    helper-text="Milliseconds"
-                    style="width: 300px"
-                    th:attr="invalid=${errors?.getFieldError('cacheTimeToLive') != null} ? 'true' : null,
-                                       invalid-text=${errors?.getFieldError('cacheTimeToLive')?.defaultMessage},
-                                       value=${form?.cacheTimeToLive}"
-                >
-                </cds-number-input>
-                <cds-button
-                    kind="danger-tertiary"
-                    size="sm"
-                    hx-confirm="Are you sure?"
-                    th:attr="hx-delete=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'},
-                                 disabled=${!isCached}"
-                >
-                    Clear cache
-                </cds-button>
-            </div>
-            <!-- Cache setting -->
             <input
                 type="hidden"
                 name="aggregatedDataProfileId"
                 th:value="${form.aggregatedDataProfileId}"
             />
             <input type="hidden" name="id" th:value="${form.id}" />
+            <input
+                type="hidden"
+                name="cacheEnabled"
+                th:value="${form?.cacheEnabled}"
+            />
+            <input
+                type="hidden"
+                name="cacheTimeToLive"
+                th:value="${form?.cacheTimeToLive}"
+            />
         </div>
 
         <div class="relation-button-bar">
@@ -335,6 +292,84 @@
                     <title>Save</title>
                 </svg>
             </cds-button>
+        </div>
+    </cds-form>
+
+    <!-- Relation cache settings (separate form, always editable) -->
+    <cds-form
+        id="relation-cache-form"
+        class="cds-theme-zone-white"
+        data-carbon-theme="white"
+    >
+        <div class="form-column">
+            <div
+                class="form-row"
+                style="
+                    flex-direction: row;
+                    align-items: center;
+                    justify-content: space-between;
+                "
+            >
+                <cds-toggle
+                    id="cacheEnabledToggle"
+                    name="cacheEnabledToggle"
+                    label-text="Cache enabled"
+                    aria-labelledby="cacheEnabled-label"
+                    hx-on:cds-toggle-changed="document.querySelector('#relationCacheEnabledHidden').value = this.checked;"
+                    th:attr="invalid=${errors?.getFieldError('cacheEnabled') != null} ? 'true' : null,
+                                 invalid-text=${errors?.getFieldError('cacheEnabled')?.defaultMessage},
+                                 checked=${form?.cacheEnabled}"
+                >
+                </cds-toggle>
+                <input
+                    type="hidden"
+                    name="cacheEnabled"
+                    id="relationCacheEnabledHidden"
+                    th:value="${form?.cacheEnabled}"
+                />
+                <cds-number-input
+                    id="cacheTimeToLive"
+                    name="cacheTimeToLive"
+                    required="true"
+                    value="5000"
+                    min="0"
+                    step="1000"
+                    max="31536000000"
+                    label="Time to live"
+                    helper-text="Milliseconds"
+                    style="width: 300px"
+                    th:attr="invalid=${errors?.getFieldError('cacheTimeToLive') != null} ? 'true' : null,
+                                       invalid-text=${errors?.getFieldError('cacheTimeToLive')?.defaultMessage},
+                                       value=${form?.cacheTimeToLive}"
+                >
+                </cds-number-input>
+                <cds-button
+                    kind="danger-tertiary"
+                    size="sm"
+                    hx-confirm="Are you sure?"
+                    th:attr="hx-delete=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'},
+                                 disabled=${!isCached}"
+                >
+                    Clear cache
+                </cds-button>
+            </div>
+            <input
+                type="hidden"
+                name="aggregatedDataProfileId"
+                th:value="${form.aggregatedDataProfileId}"
+            />
+            <input type="hidden" name="id" th:value="${form.id}" />
+            <div class="relation-button-bar">
+                <cds-button
+                    th:attr="hx-put=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relation/' + ${form.id} + '/cache'}"
+                    hx-target="#relation-edit"
+                    hx-swap="innerHTML"
+                    hx-include="#relation-cache-form *"
+                    hx-on::before-swap="if (event.detail.isError) { event.detail.shouldSwap = true; event.detail.isError = false; }"
+                >
+                    Save cache
+                </cds-button>
+            </div>
         </div>
     </cds-form>
 </div>

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -30,6 +30,7 @@
                     title-text="From"
                     label="Select a from"
                     required
+                    th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                     th:attr="
                                 invalid=${errors?.getFieldError('sourceId') != null} ? 'true' : null,
                                 invalid-text=${errors?.getFieldError('sourceId')?.defaultMessage},
@@ -57,6 +58,7 @@
                     size="lg"
                     name="connectorInstanceId"
                     required
+                    th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                     hx-get="/admin/aggregated-data-profiles/relations/edit/endpoints"
                     hx-trigger="cds-select-selected"
                     hx-target="#formRelationEndpoints"
@@ -91,6 +93,7 @@
                     size="lg"
                     name="connectorEndpointId"
                     required
+                    th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                     th:value="${#lists.isEmpty(connectorEndpoints) ? '' : (form?.connectorEndpointId != null ? form.connectorEndpointId : connectorEndpoints[0].id)}"
                     th:attr="invalid=${errors?.getFieldError('connectorEndpointId') != null or (errors != null or #lists.isEmpty(connectorEndpoints))} ? 'true' : null,
                              invalid-text=${(errors != null or #lists.isEmpty(connectorEndpoints)) ? 'No endpoints configured for selected connector' : errors?.getFieldError('connectorEndpointId')?.defaultMessage}"
@@ -141,6 +144,7 @@
                     data-textarea="#sourceToEndpointMappingCode"
                     th:data-initial="${form?.sourceToEndpointMapping}"
                     data-theme="lightgray-theme"
+                    th:attr="data-readonly=${aggregatedDataProfile?.status?.name() != 'DRAFT'} ? 'true' : null"
                     th:class="${errors?.getFieldError('sourceToEndpointMapping') != null} ? 'monaco-editor-style monaco-editor-error' : 'monaco-editor-style'"
                 ></div>
                 <div
@@ -159,6 +163,7 @@
                     label="Property Name"
                     placeholder="e.g. relation"
                     required="true"
+                    th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                     th:attr="invalid=${errors?.getFieldError('propertyName') != null} ? 'true' : null,
                             invalid-text=${errors?.getFieldError('propertyName')?.defaultMessage},
                             value=${form?.propertyName}"
@@ -199,6 +204,7 @@
                     data-textarea="#resultTransformCodeEdit"
                     th:data-initial="${form?.resultTransform}"
                     data-theme="lightgray-theme"
+                    th:attr="data-readonly=${aggregatedDataProfile?.status?.name() != 'DRAFT'} ? 'true' : null"
                     th:class="${errors?.getFieldError('resultTransform') != null} ? 'monaco-editor-style monaco-editor-error' : 'monaco-editor-style'"
                 ></div>
                 <div
@@ -276,6 +282,7 @@
         <div class="relation-button-bar">
             <cds-button
                 kind="danger"
+                th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                 th:attr="hx-get=@{'/admin/aggregated-data-profiles/' + ${form.aggregatedDataProfileId} + '/relations/edit/' + ${form.id} + '/delete'} "
                 hx-target="#modal-container"
                 hx-swap="innerHTML"
@@ -303,6 +310,7 @@
                 </svg>
             </cds-button>
             <cds-button
+                th:disabled="${aggregatedDataProfile?.status?.name() != 'DRAFT'}"
                 hx-put="/admin/relations"
                 hx-target="#relation-edit"
                 hx-swap="innerHTML"


### PR DESCRIPTION
## Summary
- Disable the **Save button** on the General tab when ADP status is FINAL
- Disable all non-cache form fields (sourceId, connectorInstance, connectorEndpoint, propertyName, JQ editors) and Save/Delete buttons on the **Relation edit form** when FINAL
- Pass `aggregatedDataProfile` to the relation edit template so it can check status
- Cache fields on the relation edit form remain editable regardless of status

Closes Integraal-Klant-en-Objectbeeld/iko-issues#270

## Test plan
- [ ] Open a FINAL ADP, verify the Save button on the General tab is disabled
- [ ] Open a FINAL ADP, click a relation — verify all fields except cache are disabled/readonly
- [ ] Verify the Save and Delete buttons on the relation panel are disabled
- [ ] Open a DRAFT ADP — verify everything is still editable as before