### PR TITLE
fix: only generate ADP schema on activation or manual trigger

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -286,11 +286,7 @@ internal class AggregatedDataProfileController(
             }
             return modelAndView
         }
-        val aggregatedDataProfile = AggregatedDataProfile.create(form).also {
-            if (aggregatedDataProfileSchemaService.isSchemaGenerationSupported(it)) {
-                it.applySchema(aggregatedDataProfileSchemaService.generateSchema(it))
-            }
-        }
+        val aggregatedDataProfile = AggregatedDataProfile.create(form)
         aggregatedDataProfileRepository.saveAndFlush(aggregatedDataProfile)
         aggregatedDataProfileService.loadRoute(aggregatedDataProfile)
 
@@ -322,19 +318,7 @@ internal class AggregatedDataProfileController(
             }
             return modelAndView
         }
-        val previousConnectorInstanceId = aggregatedDataProfile.connectorInstanceId
-        val previousResultTransform = aggregatedDataProfile.resultTransform.expression
         aggregatedDataProfile.handle(form)
-        if (aggregatedDataProfileSchemaService.isSchemaGenerationSupported(aggregatedDataProfile)) {
-            if (
-                aggregatedDataProfile.resultTransform.expression != previousResultTransform ||
-                aggregatedDataProfile.connectorInstanceId != previousConnectorInstanceId
-            ) {
-                aggregatedDataProfile.applySchema(aggregatedDataProfileSchemaService.generateSchema(aggregatedDataProfile))
-            }
-        } else if (aggregatedDataProfile.schema != null) {
-            aggregatedDataProfile.resetSchema()
-        }
         aggregatedDataProfileRepository.save(aggregatedDataProfile)
         if (aggregatedDataProfile.isActive) {
             aggregatedDataProfileService.reloadRoute(aggregatedDataProfile)
@@ -606,6 +590,11 @@ internal class AggregatedDataProfileController(
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
         aggregatedDataProfileService.activateVersion(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
+        if (aggregatedDataProfileSchemaService.isSchemaGenerationSupported(aggregatedDataProfile)) {
+            aggregatedDataProfile.applySchema(aggregatedDataProfileSchemaService.generateSchema(aggregatedDataProfile))
+            aggregatedDataProfileRepository.save(aggregatedDataProfile)
+        }
         return details(id, isHxRequest)
     }
 


### PR DESCRIPTION
## Summary
- Removed automatic schema generation from ADP create and edit flows to prevent validation errors caused by incomplete/incorrect result transforms
- Schema is now automatically generated when an ADP is activated (`isActive = true`)
- Manual schema regeneration remains available via the existing `/{id}/schema/regenerate` endpoint for non-active ADPs

## Test plan
- [ ] Create a new ADP with an invalid result transform — verify no schema validation error on save
- [ ] Edit an ADP's result transform — verify no schema validation error on save
- [ ] Activate an ADP — verify schema is generated automatically
- [ ] Use the manual regenerate button on a non-active ADP — verify schema is generated