### PR TITLE
Allow editing and selecting config properties.

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -414,6 +414,26 @@ class ConnectorController(
         ),
     )
 
+    @GetMapping("/{id}/instances/{instanceId}/config/{configKey}/edit")
+    fun editConnectorInstanceConfigPage(
+        @PathVariable id: UUID,
+        @PathVariable instanceId: UUID,
+        @PathVariable configKey: String,
+    ): ModelAndView {
+        val instance =
+            connectorInstanceRepository
+                .findById(instanceId)
+                .orElseThrow { NoSuchElementException("Connector instance not found") }
+        return ModelAndView(
+            "fragments/internal/connector/form-create-connector-instance-config",
+            mapOf(
+                "connectorId" to id,
+                "instanceId" to instanceId,
+                "config" to ConnectorInstanceConfigEditForm(configKey, instance.config[configKey] ?: ""),
+            ),
+        )
+    }
+
     @PostMapping("/{id}/instances/{instanceId}/config")
     fun createConnectorInstanceConfigPage(
         @PathVariable id: UUID,

--- a/src/main/resources/templates/fragments/internal/connector/config-value.html
+++ b/src/main/resources/templates/fragments/internal/connector/config-value.html
@@ -15,5 +15,5 @@
  -->
 
 <th:block th:fragment="config-value">
-    <div th:text="${configValue}" style="user-select: text; cursor: text;"></div>
+    <div th:text="${configValue}" style="user-select: text; cursor: text"></div>
 </th:block>

--- a/src/main/resources/templates/fragments/internal/connector/config-value.html
+++ b/src/main/resources/templates/fragments/internal/connector/config-value.html
@@ -15,5 +15,5 @@
  -->
 
 <th:block th:fragment="config-value">
-    <div th:text="${configValue}"></div>
+    <div th:text="${configValue}" style="user-select: text; cursor: text;"></div>
 </th:block>

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
@@ -181,6 +181,7 @@
                                     <cds-table-cell
                                         class="pointer"
                                         th:hx-get="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}/config/${config.key}|}"
+                                        hx-trigger="click once"
                                     >
                                         <svg
                                             focusable="false"
@@ -259,6 +260,13 @@
                                                 Options
                                             </span>
                                             <cds-overflow-menu-body flipped="">
+                                                <cds-overflow-menu-item
+                                                    th:hx-get="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}/config/${config.key}/edit|}"
+                                                    hx-target="#modal-container"
+                                                    th:disabled="${connector.final}"
+                                                >
+                                                    Edit
+                                                </cds-overflow-menu-item>
                                                 <cds-overflow-menu-item
                                                     hx-confirm="Are you sure you want to delete this config?"
                                                     th:hx-delete="@{|/admin/connectors/${connector.id}/instances/${connectorInstance.id}/config/${config.key}|}"

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
@@ -22,7 +22,7 @@
 >
     <cds-modal-header>
         <cds-modal-close-button></cds-modal-close-button>
-        <cds-modal-label>Add new connector instance config</cds-modal-label>
+        <cds-modal-label th:text="${config?.key != null} ? 'Edit connector instance config' : 'Add new connector instance config'">Add new connector instance config</cds-modal-label>
         <cds-modal-heading>Connector Instance Config</cds-modal-heading>
     </cds-modal-header>
     <cds-modal-body>
@@ -34,7 +34,8 @@
                         size="lg"
                         th:value="${config?.key}"
                         th:attr="invalid=${errors?.getFieldError('key') != null} ? 'true' : null,
-                                        invalid-text=${errors?.getFieldError('key')?.defaultMessage}"
+                                        invalid-text=${errors?.getFieldError('key')?.defaultMessage},
+                                        readonly=${config?.key != null} ? 'true' : null"
                         label="Key"
                     >
                     </cds-text-input>

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
@@ -22,7 +22,10 @@
 >
     <cds-modal-header>
         <cds-modal-close-button></cds-modal-close-button>
-        <cds-modal-label th:text="${config?.key != null} ? 'Edit connector instance config' : 'Add new connector instance config'">Add new connector instance config</cds-modal-label>
+        <cds-modal-label
+            th:text="${config?.key != null} ? 'Edit connector instance config' : 'Add new connector instance config'"
+            >Add new connector instance config</cds-modal-label
+        >
         <cds-modal-heading>Connector Instance Config</cds-modal-heading>
     </cds-modal-header>
     <cds-modal-body>


### PR DESCRIPTION
## What problem(s) was I solving?

Two usability gaps in connector instance config management:
1. Revealing a config value and then trying to select/copy the text caused the selection to disappear, because clicking triggered a new HTMX request that replaced the DOM node.
2. Changing a config value required deleting the property and recreating it from scratch.

## What user-facing changes did I ship?

- Revealed config values can now be selected and copied.
- An **Edit** option is added to the overflow menu per config row, opening a modal with the key (read-only) and current value pre-filled.

## How I implemented it

- Added `hx-trigger="click once"` to the reveal cell so HTMX only fires once; subsequent clicks (e.g. to start a text selection) no longer re-fetch and replace the value.
- Added `user-select: text; cursor: text` to the revealed value `<div>` to override any Carbon CSS that might block selection.
- Added a `GET /{id}/instances/{instanceId}/config/{configKey}/edit` endpoint in `ConnectorController` that loads the existing key/value and returns the config modal with them pre-filled.
- Reused the existing `POST /{id}/instances/{instanceId}/config` handler — it already overwrites a key if it exists.
- The modal label and key input adapt based on whether a `config` model attribute is present (edit) or not (add); key is `readonly` during edit.

## How to verify it

### Manual Testing

- [ ] Open a connector instance with at least one config property.
- [ ] Click the eye icon on a config row → value appears.
- [ ] Select the revealed value text with the mouse → selection stays after releasing the button.
- [ ] Open the overflow menu on a config row → **Edit** option is present.
- [ ] Click **Edit** → modal opens with the key pre-filled and read-only, value pre-filled.
- [ ] Change the value and save → table refreshes with the updated value.
- [ ] Verify **Add config** still works as before (key editable, no pre-filled values).
- [ ] Verify **Delete** still works as before.

## Description for the changelog

Connector instance config properties can now be edited in place via a new Edit option in the row menu. Revealed config values can also be selected and copied without the selection being lost.