### PR TITLE
fix: standardize copyright heading across all files (#264)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Ritense BV, the Netherlands.
+// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+// Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.

--- a/imports/open-klanten/database/1-setup-klanten.sql
+++ b/imports/open-klanten/database/1-setup-klanten.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/imports/open-klanten/database/1-setup-klanten.sql
+++ b/imports/open-klanten/database/1-setup-klanten.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright (C) 2026 Ritense BV, the Netherlands.
+// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+// Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/ApplicationConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/ApplicationConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/ApplicationConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/ApplicationConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/IkoApplication.kt
+++ b/src/main/kotlin/com/ritense/iko/IkoApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/IkoApplication.kt
+++ b/src/main/kotlin/com/ritense/iko/IkoApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/autoconfiguration/AggregatedDataProfileConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/autoconfiguration/AggregatedDataProfileConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/autoconfiguration/AggregatedDataProfileConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/autoconfiguration/AggregatedDataProfileConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileTemplatesRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileTemplatesRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileTemplatesRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileTemplatesRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AuthRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AuthRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AuthRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/AuthRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParam.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParam.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParam.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParam.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/MapAggregator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/MapAggregator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/MapAggregator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/MapAggregator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileCacheSetting.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileCacheSetting.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileCacheSetting.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileCacheSetting.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileDTO.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileDTO.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileDTO.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileDTO.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileSchema.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileSchema.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileSchema.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileSchema.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EndpointTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EndpointTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EndpointTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EndpointTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/EntityStatus.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Relation.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Relation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Relation.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Relation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationCacheSettings.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationCacheSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationCacheSettings.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationCacheSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationEndpointTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationEndpointTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationEndpointTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationEndpointTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Roles.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Roles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Roles.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Roles.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Transform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Transform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Transform.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Transform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Version.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Version.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/domain/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/error/AggregatedDomainError.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/error/AggregatedDomainError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/error/AggregatedDomainError.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/error/AggregatedDomainError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/AggregatedDataProfileSchemaProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/AggregatedDataProfileSchemaProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/AggregatedDataProfileSchemaProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/AggregatedDataProfileSchemaProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/ContainerParamsProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/ContainerParamsProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/ContainerParamsProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/processor/ContainerParamsProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/repository/AggregatedDataProfileRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGenerator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGenerator.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGenerator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableDeserializer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableDeserializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableDeserializer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableDeserializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableSerializer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableSerializer.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/serializer/PageableSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/FinalizationImpact.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/autoconfiguration/CacheConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/autoconfiguration/CacheConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/autoconfiguration/CacheConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/autoconfiguration/CacheConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/CacheEntry.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/CacheEntry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/CacheEntry.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/CacheEntry.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/CacheSettings.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/CacheSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/CacheSettings.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/CacheSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/Cacheable.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/Cacheable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/domain/Cacheable.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/domain/Cacheable.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/processor/CacheProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/processor/CacheProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/processor/CacheProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/processor/CacheProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/service/CacheService.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/service/CacheService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/cache/service/CacheService.kt
+++ b/src/main/kotlin/com/ritense/iko/cache/service/CacheService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/ErrorHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/ErrorHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/ErrorHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/ErrorHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerService.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerService.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/GlobalErrorHandlerService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/IkoConstants.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/IkoConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/IkoConstants.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/IkoConstants.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/IkoRouteHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/IkoRouteHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/IkoRouteHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/IkoRouteHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/RestConfigurationRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/RestConfigurationRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/RestConfigurationRoute.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/RestConfigurationRoute.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/configuration/CamelConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/configuration/CamelConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/camel/configuration/CamelConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/camel/configuration/CamelConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorConfigRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorConfigRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorConfigRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorConfigRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorDispatcherRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorDispatcherRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorDispatcherRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/ConnectorDispatcherRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointRestRoutesBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointRestRoutesBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointRestRoutesBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointRestRoutesBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointValidationRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointValidationRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointValidationRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointValidationRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/Connector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorDTO.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorDTO.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorDTO.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorDTO.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpoint.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpoint.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRole.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRole.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRole.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRole.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorInstance.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorInstance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorInstance.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/ConnectorInstance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/Version.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/domain/Version.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/domain/Version.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/error/ConnectorDomainError.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/error/ConnectorDomainError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/error/ConnectorDomainError.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/error/ConnectorDomainError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/exception/AggregatedProfileNotFound.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/exception/AggregatedProfileNotFound.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/exception/AggregatedProfileNotFound.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/exception/AggregatedProfileNotFound.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/exception/EndpointValidationFailed.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/exception/EndpointValidationFailed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/exception/EndpointValidationFailed.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/exception/EndpointValidationFailed.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/processor/ConnectorLookupProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/processor/ConnectorLookupProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/processor/ConnectorLookupProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/processor/ConnectorLookupProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRoleRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRoleRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRoleRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorEndpointRoleRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorInstanceRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorInstanceRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorInstanceRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorInstanceRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/service/RouteDependencyService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/RouteDependencyService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/connectors/service/RouteDependencyService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/RouteDependencyService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/AesGcmEncryptionService.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/AesGcmEncryptionService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/AesGcmEncryptionService.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/AesGcmEncryptionService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/AesGcmStringAttributeConverter.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/AesGcmStringAttributeConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/AesGcmStringAttributeConverter.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/AesGcmStringAttributeConverter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/CryptoAutoConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/CryptoAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/crypto/CryptoAutoConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/crypto/CryptoAutoConfiguration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/HomeController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/HomeController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/HomeController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/HomeController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/TestController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/TestController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/TestController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/TestController.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileAddForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileAddForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileAddForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileAddForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileCacheForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileCacheForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileCacheForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileCacheForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/CreateVersionForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/CreateVersionForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/CreateVersionForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/CreateVersionForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/DeleteRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/DeleteRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/DeleteRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/DeleteRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Endpoint.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Endpoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Endpoint.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Endpoint.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/ExceptionResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/ExceptionResponse.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/ExceptionResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/MenuItem.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/MenuItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/MenuItem.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/MenuItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Relation.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Relation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Relation.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Relation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/RelationCacheForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Route.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Route.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Route.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Route.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Source.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Source.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/Source.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/Source.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/TraceEvent.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/TraceEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/TraceEvent.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/TraceEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/Connector.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/Connector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/Connector.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/Connector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEndpointConfigForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEndpointConfigForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEndpointConfigForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorEndpointConfigForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceConfigEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceConfigEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceConfigEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceConfigEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceRolesEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceRolesEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceRolesEditForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorInstanceRolesEditForm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfile.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileCheck.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileCheck.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileCheck.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileCheck.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueAggregatedDataProfileValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelation.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelation.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationCheck.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationCheck.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationCheck.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationCheck.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCode.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCode.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCodeValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCodeValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCodeValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidConnectorCodeValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyName.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyName.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyName.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyName.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemver.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemver.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemverValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemverValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemverValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidSemverValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransform.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransform.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransformValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransformValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransformValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/ValidTransformValidator.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/security/SecurityContextHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityContextHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/ritense/iko/security/SecurityContextHelper.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityContextHelper.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1,5 +1,5 @@
 /*
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -1,5 +1,5 @@
 /*
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/add.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/cache.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/detail-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/edit-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/filter-results.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list-page.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/pagination.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/preview-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/preview-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/preview-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/preview-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/relations-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/schema-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/schema-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/aggregated-data-profile/schema-panel.html
+++ b/src/main/resources/templates/fragments/internal/aggregated-data-profile/schema-panel.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/config-value.html
+++ b/src/main/resources/templates/fragments/internal/connector/config-value.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/config-value.html
+++ b/src/main/resources/templates/fragments/internal/connector/config-value.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector-instance.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/details-page-connector.html
+++ b/src/main/resources/templates/fragments/internal/connector/details-page-connector.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/filter-results-page.html
+++ b/src/main/resources/templates/fragments/internal/connector/filter-results-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/filter-results-page.html
+++ b/src/main/resources/templates/fragments/internal/connector/filter-results-page.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/connector/filter-results.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/filter-results.html
+++ b/src/main/resources/templates/fragments/internal/connector/filter-results.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-endpoint.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-endpoint.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-endpoint.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-endpoint.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-config.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-role.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-role.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-role.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance-role.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector-instance.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/form-create-connector.html
+++ b/src/main/resources/templates/fragments/internal/connector/form-create-connector.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/list-page-connectors.html
+++ b/src/main/resources/templates/fragments/internal/connector/list-page-connectors.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/list-page-connectors.html
+++ b/src/main/resources/templates/fragments/internal/connector/list-page-connectors.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/list.html
+++ b/src/main/resources/templates/fragments/internal/connector/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/pagination.html
+++ b/src/main/resources/templates/fragments/internal/connector/pagination.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/connector/pagination.html
+++ b/src/main/resources/templates/fragments/internal/connector/pagination.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/menu.html
+++ b/src/main/resources/templates/fragments/internal/menu.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/menu.html
+++ b/src/main/resources/templates/fragments/internal/menu.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/add.html
+++ b/src/main/resources/templates/fragments/internal/relation/add.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/add.html
+++ b/src/main/resources/templates/fragments/internal/relation/add.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/cache.html
+++ b/src/main/resources/templates/fragments/internal/relation/cache.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/cache.html
+++ b/src/main/resources/templates/fragments/internal/relation/cache.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/delete.html
+++ b/src/main/resources/templates/fragments/internal/relation/delete.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/delete.html
+++ b/src/main/resources/templates/fragments/internal/relation/delete.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/edit.html
+++ b/src/main/resources/templates/fragments/internal/relation/edit.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/list.html
+++ b/src/main/resources/templates/fragments/internal/relation/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/relation/list.html
+++ b/src/main/resources/templates/fragments/internal/relation/list.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/create-version-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/create-version-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/create-version-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/create-version-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-connector-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
+++ b/src/main/resources/templates/fragments/internal/versioning/finalize-preview-modal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
+++ b/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
+++ b/src/main/resources/templates/fragments/internal/versioning/page-header-versioned.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) 2026 Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/BaseIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/BaseIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/BaseIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/ExampleUnitIntTest.kt
+++ b/src/test/kotlin/com/ritense/iko/ExampleUnitIntTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/ExampleUnitIntTest.kt
+++ b/src/test/kotlin/com/ritense/iko/ExampleUnitIntTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/JQTest.kt
+++ b/src/test/kotlin/com/ritense/iko/JQTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/JQTest.kt
+++ b/src/test/kotlin/com/ritense/iko/JQTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/MockWebServerExtension.kt
+++ b/src/test/kotlin/com/ritense/iko/MockWebServerExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/MockWebServerExtension.kt
+++ b/src/test/kotlin/com/ritense/iko/MockWebServerExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/PetMockServer.kt
+++ b/src/test/kotlin/com/ritense/iko/PetMockServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/PetMockServer.kt
+++ b/src/test/kotlin/com/ritense/iko/PetMockServer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/PetMockServerIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/PetMockServerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/PetMockServerIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/PetMockServerIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
+++ b/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
+++ b/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/TransformTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/TransformTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/TransformTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/TransformTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/AggregatedDataProfileRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParamRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParamRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParamRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/ContainerParamRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/EndpointsRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/EndpointsRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/EndpointsRestIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/EndpointsRestIntegrationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregatorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregatorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/camel/PairAggregatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/AggregatedDataProfileTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RelationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RolesTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RolesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RolesTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/domain/RolesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaServiceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaServiceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/AggregatedDataProfileSchemaServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrerTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrerTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/JsonSchemaInferrerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGeneratorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGeneratorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/aggregateddataprofile/schema/OpenApiMockGeneratorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/cache/domain/CacheableTest.kt
+++ b/src/test/kotlin/com/ritense/iko/cache/domain/CacheableTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/cache/domain/CacheableTest.kt
+++ b/src/test/kotlin/com/ritense/iko/cache/domain/CacheableTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/db/AesGcmStringAttributeConverterTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/db/AesGcmStringAttributeConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/db/AesGcmStringAttributeConverterTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/db/AesGcmStringAttributeConverterTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRoleTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRoleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRoleTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorEndpointRoleTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/domain/ConnectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/json/serializer/CustomSerializersTest.kt
+++ b/src/test/kotlin/com/ritense/iko/json/serializer/CustomSerializersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/json/serializer/CustomSerializersTest.kt
+++ b/src/test/kotlin/com/ritense/iko/json/serializer/CustomSerializersTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/controller/ConnectorControllerInstanceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/controller/ConnectorControllerInstanceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/controller/ConnectorControllerInstanceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/controller/ConnectorControllerInstanceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileFormTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileFormTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileFormTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/AggregatedDataProfileFormTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/RelationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/RelationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/RelationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/RelationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileFormTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileFormTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileFormTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/TestAggregatedDataProfileFormTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidatorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidatorTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/model/validation/ValidPropertyNameValidatorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.css.template
+++ b/templates/licenseHeaderFile.css.template
@@ -1,5 +1,5 @@
 /*
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright $YEAR Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.css.template
+++ b/templates/licenseHeaderFile.css.template
@@ -1,5 +1,5 @@
 /*
- Copyright (C) $YEAR Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.html.template
+++ b/templates/licenseHeaderFile.html.template
@@ -1,5 +1,5 @@
 <!--
- Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ Copyright $YEAR Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.html.template
+++ b/templates/licenseHeaderFile.html.template
@@ -1,5 +1,5 @@
 <!--
- Copyright (C) $YEAR Ritense BV, the Netherlands.
+ Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 
  Licensed under EUPL, Version 1.2 (the "License");
  you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.kt.template
+++ b/templates/licenseHeaderFile.kt.template
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ * Copyright $YEAR Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.kt.template
+++ b/templates/licenseHeaderFile.kt.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) $YEAR Ritense BV, the Netherlands.
+ * Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
  *
  * Licensed under EUPL, Version 1.2 (the "License");
  * you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.kts.template
+++ b/templates/licenseHeaderFile.kts.template
@@ -1,4 +1,4 @@
-// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+// Copyright $YEAR Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.

--- a/templates/licenseHeaderFile.kts.template
+++ b/templates/licenseHeaderFile.kts.template
@@ -1,4 +1,4 @@
-// Copyright (C) $YEAR Ritense BV, the Netherlands.
+// Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
 //
 // Licensed under EUPL, Version 1.2 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Updated the four Spotless license header templates (`kt`, `kts`, `html`, `css`) to use the new canonical copyright line: `Copyright 2015-2022 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.`
- Ran `./gradlew spotlessApply` to propagate the new header to all 188 Kotlin/Gradle/HTML/CSS sources.
- Updated the orphan SQL header in `imports/open-klanten/database/1-setup-klanten.sql` (not covered by Spotless).

Closes Integraal-Klant-en-Objectbeeld/iko-issues#264

## Test plan
- [x] `./gradlew spotlessCheck` passes
- [x] Reviewer spot-checks a few source files to confirm the new header text