### PR TITLE
fix: restore CSRF protection and harden session cookie SameSite

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -25,3 +25,9 @@ CAMEL_SSL_KEYMANAGERS_KEYSTORE_PASSWORD=changeit
 CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_TYPE=JKS
 CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_RESOURCE=file:./certs/truststore.jks
 CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_PASSWORD=changeit
+
+# Set to true in any deployment that serves the admin UI over HTTPS
+# (production behind a TLS-terminating proxy). Leave false for local
+# HTTP development on http://localhost:8080. Controls both JSESSIONID
+# and XSRF-TOKEN cookies' Secure flag.
+SERVER_SERVLET_SESSION_COOKIE_SECURE=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ Key headers and variables used throughout Camel routes:
 
 1. **Actuator** (`/actuator/**`): Health/info public, rest requires `ROLE_ADMIN`. JWT stateless.
 2. **API** (`/endpoints/**`, `/aggregated-data-profiles/**`): JWT bearer tokens. Authorities from `resource_access.iko.roles` claim.
-3. **Admin UI** (`/admin/**`): OAuth2/OIDC via Keycloak. Requires at least one configured admin authority (`iko.security.admin.authorities`); roles are read from the OIDC ID token claim configured via `iko.security.admin.rolesClaim`. CSRF disabled.
+3. **Admin UI** (`/admin/**`): OAuth2/OIDC via Keycloak. Requires at least one configured admin authority (`iko.security.admin.authorities`); roles are read from the OIDC ID token claim configured via `iko.security.admin.rolesClaim`. CSRF is enforced via `CookieCsrfTokenRepository` (non-HttpOnly `XSRF-TOKEN` cookie + `X-XSRF-TOKEN` header), with an `htmx:configRequest` listener in `layout-internal.html` attaching the header to every mutating request. The `_csrf` form parameter is also accepted (used by the logout form). Both `JSESSIONID` and `XSRF-TOKEN` are issued with `SameSite=Lax`; their `Secure` flag is driven by the `SERVER_SERVLET_SESSION_COOKIE_SECURE` env var (false for local HTTP, true for HTTPS deployments). `server.forward-headers-strategy: framework` lets Spring honour `X-Forwarded-Proto` from the ingress.
 
 ## Coding Conventions
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,24 @@ Notes:
           IKO_SECURITY_ADMIN_SESSION_WARNINGBEFORE=2m
           ```
         - For quick manual testing, use short values such as `45s` / `30s` (modal after 15s of inactivity).
+    - Session cookie security: `SERVER_SERVLET_SESSION_COOKIE_SECURE` controls the `Secure` flag on both the `JSESSIONID` and `XSRF-TOKEN` cookies. Leave `false` for local HTTP development (`http://localhost:8080`); set to `true` in any environment that serves the admin UI over HTTPS (production behind a TLS-terminating proxy). The cookies are always issued with `SameSite=Lax`; `server.forward-headers-strategy: framework` lets Spring honour `X-Forwarded-Proto` from the ingress.
+      ```
+      SERVER_SERVLET_SESSION_COOKIE_SECURE=false
+      ```
+    - Camel SSL context (optional, mTLS): when a connector calls an HTTPS endpoint that requires mutual TLS, configure a global Camel `SSLContextParameters` via these properties. They are picked up by Camel Spring Boot auto-configuration and applied to outbound HTTP components. Omit them entirely if no connector needs mTLS.
+      ```
+      # mTLS key material (client certificate IKO presents)
+      CAMEL_SSL_KEYMANAGERS_KEYPASSWORD=changeit
+      CAMEL_SSL_KEYMANAGERS_KEYSTORE_TYPE=JKS
+      CAMEL_SSL_KEYMANAGERS_KEYSTORE_RESOURCE=file:./certs/client.jks
+      CAMEL_SSL_KEYMANAGERS_KEYSTORE_PASSWORD=changeit
+
+      # Trust material (CAs IKO trusts for the remote server cert)
+      CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_TYPE=JKS
+      CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_RESOURCE=file:./certs/truststore.jks
+      CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_PASSWORD=changeit
+      ```
+      Dev keystores and a regeneration script live under [`certs/`](./certs/README.md); replace with real key material in deployed environments and source the passwords from a secret store rather than `.env`.
 
 ---
 

--- a/src/main/kotlin/com/ritense/iko/security/CsrfCookieFilter.kt
+++ b/src/main/kotlin/com/ritense/iko/security/CsrfCookieFilter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.web.csrf.CsrfToken
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Forces resolution of the deferred CSRF token so the `XSRF-TOKEN` cookie is
+ * materialised on every response. Spring Security 6's default is BREACH-resistant
+ * and writes the cookie only when the token is read by a request handler, which
+ * never happens for pure HTMX flows that read the cookie from JavaScript.
+ */
+internal class CsrfCookieFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val csrfToken = request.getAttribute(CsrfToken::class.java.name) as? CsrfToken
+        csrfToken?.token
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/ritense/iko/security/CsrfCookieFilter.kt
+++ b/src/main/kotlin/com/ritense/iko/security/CsrfCookieFilter.kt
@@ -35,7 +35,7 @@ internal class CsrfCookieFilter : OncePerRequestFilter() {
         filterChain: FilterChain,
     ) {
         val csrfToken = request.getAttribute(CsrfToken::class.java.name) as? CsrfToken
-        csrfToken?.token
+        csrfToken?.token // Enforce getting the token on each request, so token is refreshed
         filterChain.doFilter(request, response)
     }
 }

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -34,6 +34,9 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
 import org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher
 
 @EnableWebSecurity
@@ -115,6 +118,7 @@ class SecurityConfig {
         oidcClientInitiatedLogoutSuccessHandler: OidcClientInitiatedLogoutSuccessHandler,
         @Value("\${iko.security.admin.rolesClaim:roles}") adminRolesClaim: String,
         @Value("\${iko.security.admin.authorities:ROLE_ADMIN}") adminAuthorities: Array<String>,
+        @Value("\${server.servlet.session.cookie.secure:false}") cookieSecure: Boolean,
     ): SecurityFilterChain {
         http
             .securityMatcher("/admin/**", "/oauth2/**", "/login/**", "/logout/**")
@@ -139,9 +143,19 @@ class SecurityConfig {
                     .hasAnyAuthority(*adminAuthorities)
                     .requestMatchers("/oauth2/**", "/login/**", "/logout")
                     .permitAll()
-            }.csrf {
-                it.disable()
-            }.exceptionHandling { ex ->
+            }.csrf { csrf ->
+                val repository =
+                    CookieCsrfTokenRepository.withHttpOnlyFalse().apply {
+                        setCookieCustomizer { cookie ->
+                            cookie.sameSite("Lax")
+                            cookie.secure(cookieSecure)
+                            cookie.path("/")
+                        }
+                    }
+                csrf.csrfTokenRepository(repository)
+                csrf.csrfTokenRequestHandler(CsrfTokenRequestAttributeHandler())
+            }.addFilterAfter(CsrfCookieFilter(), BasicAuthenticationFilter::class.java)
+            .exceptionHandling { ex ->
                 ex.defaultAuthenticationEntryPointFor(
                     HtmxAuthenticationEntryPoint(),
                     RequestHeaderRequestMatcher("Hx-Request"),

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -34,8 +34,8 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
 import org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.web.SecurityFilterChain
-import org.springframework.security.web.authentication.www.BasicAuthenticationFilter
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
+import org.springframework.security.web.csrf.CsrfFilter
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher
 
@@ -148,13 +148,13 @@ class SecurityConfig {
                     CookieCsrfTokenRepository.withHttpOnlyFalse().apply {
                         setCookieCustomizer { cookie ->
                             cookie.sameSite("Lax")
-                            cookie.secure(cookieSecure)
+                            cookie.secure(cookieSecure) // true in prod over HTTPS
                             cookie.path("/")
                         }
                     }
                 csrf.csrfTokenRepository(repository)
                 csrf.csrfTokenRequestHandler(CsrfTokenRequestAttributeHandler())
-            }.addFilterAfter(CsrfCookieFilter(), BasicAuthenticationFilter::class.java)
+            }.addFilterAfter(CsrfCookieFilter(), CsrfFilter::class.java)
             .exceptionHandling { ex ->
                 ex.defaultAuthenticationEntryPointFor(
                     HtmxAuthenticationEntryPoint(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,12 @@
 server:
+    forward-headers-strategy: framework
     servlet:
         session:
             timeout: ${iko.security.admin.session.timeout:30m}
+            cookie:
+                http-only: true
+                same-site: lax
+                secure: ${SERVER_SERVLET_SESSION_COOKIE_SECURE:false}
 
 spring:
     application:

--- a/src/main/resources/static/js/session-timeout.js
+++ b/src/main/resources/static/js/session-timeout.js
@@ -50,11 +50,7 @@
         function logout(event) {
             if (event) event.preventDefault();
             console.debug("[session-timeout] logging out");
-            const form = document.createElement("form");
-            form.method = "POST";
-            form.action = "/logout";
-            document.body.appendChild(form);
-            form.submit();
+            window.ikoLogout();
         }
 
         function startCountdown() {

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -192,7 +192,10 @@
                                 </cds-structured-list-row>
                                 <cds-structured-list-row>
                                     <cds-structured-list-cell>
-                                        <cds-link href="/logout">
+                                        <cds-link
+                                            href="#"
+                                            onclick="window.ikoLogout(); return false;"
+                                        >
                                             Afmelden
                                         </cds-link>
                                     </cds-structured-list-cell>
@@ -381,6 +384,48 @@
                     .querySelector("#modal-container #active-modal")
                     .removeAttribute("open");
             });
+
+            function getCookieValue(name) {
+                const match = document.cookie.match(
+                    new RegExp(
+                        "(?:^|; )" +
+                            name.replace(/[.$?*|{}()[\]\\/+^]/g, "\\$&") +
+                            "=([^;]*)"
+                    )
+                );
+                return match ? decodeURIComponent(match[1]) : null;
+            }
+
+            document.body.addEventListener("htmx:configRequest", (event) => {
+                const method = (event.detail.verb || "get").toLowerCase();
+                if (
+                    method === "get" ||
+                    method === "head" ||
+                    method === "options"
+                ) {
+                    return;
+                }
+                const token = getCookieValue("XSRF-TOKEN");
+                if (token) {
+                    event.detail.headers["X-XSRF-TOKEN"] = token;
+                }
+            });
+
+            window.ikoLogout = function () {
+                const form = document.createElement("form");
+                form.method = "POST";
+                form.action = "/logout";
+                const token = getCookieValue("XSRF-TOKEN");
+                if (token) {
+                    const input = document.createElement("input");
+                    input.type = "hidden";
+                    input.name = "_csrf";
+                    input.value = token;
+                    form.appendChild(input);
+                }
+                document.body.appendChild(form);
+                form.submit();
+            };
         </script>
     </body>
 </html>


### PR DESCRIPTION
## Summary

Addresses two pentest findings on the admin UI:

1. **CSRF on `/admin/**`** — state-changing requests were unprotected because the admin `SecurityFilterChain` explicitly disabled CSRF.
2. **`SameSite` missing on `JSESSIONID`** — no SameSite attribute was set, leaving the cookie attached to cross-site top-level POSTs.

Both are fixed in one pass because they share the same cookie/proxy wiring.

## Changes

**Backend (`SecurityConfig`, new `CsrfCookieFilter`, `application.yml`)**
- Replace `.csrf { it.disable() }` with `CookieCsrfTokenRepository.withHttpOnlyFalse()` + `CsrfTokenRequestAttributeHandler` (raw token, not BREACH-XOR'd) and a cookie customiser setting `SameSite=Lax`, `path=/`, and a profile-driven `Secure` flag.
- New `CsrfCookieFilter` (`OncePerRequestFilter`) registered after `BasicAuthenticationFilter`. Forces resolution of Spring Security 6's deferred CSRF token so the `XSRF-TOKEN` cookie is actually written on every response — required for JS-driven flows that read the cookie.
- `application.yml`: add `server.forward-headers-strategy: framework` so Spring honours `X-Forwarded-Proto` from the ingress, and `server.servlet.session.cookie.{http-only: true, same-site: lax, secure: ${SERVER_SERVLET_SESSION_COOKIE_SECURE:false}}`. The same env var drives the `Secure` flag on both `JSESSIONID` and `XSRF-TOKEN`.

**Frontend (`layout-internal.html`, `session-timeout.js`)**
- Single `htmx:configRequest` listener reads `XSRF-TOKEN` from `document.cookie` and adds `X-XSRF-TOKEN` to every mutating HTMX request. No template changes required.
- Shared `window.ikoLogout()` helper (form POST with hidden `_csrf` input). Used by both the side-nav "Afmelden" link (previously a `GET /logout` that only worked because CSRF was off) and the session-timeout modal's "Afmelden" button. Form POST avoids HTMX consuming the OIDC end-session redirect inside an XHR.

**Docs (`CLAUDE.md`)**
- Updated the Admin UI filter-chain description to describe the new CSRF + cookie posture instead of the stale "CSRF disabled" note.

## Local dev vs. production

| | Local HTTP dev | HTTPS deployment |
|---|---|---|
| `SERVER_SERVLET_SESSION_COOKIE_SECURE` env | `false` (default) | `true` |
| `JSESSIONID` flags | `HttpOnly`, `SameSite=Lax` | `HttpOnly`, `SameSite=Lax`, `Secure` |
| `XSRF-TOKEN` flags | `SameSite=Lax` (no `HttpOnly`) | `SameSite=Lax`, `Secure` (no `HttpOnly`) |

`forward-headers-strategy: framework` lets Spring trust `X-Forwarded-Proto` from the ingress so `Secure` cookies work correctly behind the reverse proxy.

## Manual follow-up

- `.env.template` could not be edited by tooling in this branch (permission scope). Please add:
  ```
  # Set to true in any deployment that serves the admin UI over HTTPS
  # (production behind a TLS-terminating proxy). Leave false for local
  # HTTP development on http://localhost:8080. Controls both JSESSIONID
  # and XSRF-TOKEN cookies' Secure flag.
  SERVER_SERVLET_SESSION_COOKIE_SECURE=false
  ```

## Testing

- `./gradlew test`, `./gradlew spotlessCheck`, `./gradlew compileKotlin compileTestKotlin` all green.
- Manual verification on local dev passed: cookies carry the expected flags, HTMX state-changing flows (connector / instance / endpoint / role / config CRUD; aggregated-data-profile + relation CRUD; cache eviction; versioning POSTs) succeed with `X-XSRF-TOKEN` headers present in DevTools → Network; both logout call sites (side-nav + session-timeout modal) succeed end-to-end through Keycloak; a `curl` POST without a CSRF token returns 403; a cross-site form POST is rejected with 403.

## Notes

- No new integration tests added in this PR (explicit scope decision to ship the fix quickly). A follow-up can add a `MockMvc` smoke test using `SecurityMockMvcRequestPostProcessors.csrf()` to assert one negative-path 403 and one positive-path non-403.