### PR TITLE
feat: show running IKO version in admin Account panel (#284)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
-version=1.2.1
+version=1.3.0

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -637,3 +637,9 @@ cds-form-item {
     align-items: center;
     gap: var(--cds-spacing-03);
 }
+
+.iko-version-line {
+    padding: var(--cds-spacing-05);
+    font-size: var(--cds-body-compact-01-font-size);
+    color: var(--cds-text-secondary);
+}

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -202,6 +202,10 @@
                                 </cds-structured-list-row>
                             </cds-structured-list-body>
                         </cds-structured-list>
+                        <p
+                            class="iko-version-line"
+                            th:text="|Version ${@buildProperties.version} (${#temporals.format(@buildProperties.time, 'yyyy-MM-dd', 'UTC')})|"
+                        ></p>
                     </cds-tab-panel>
                 </cds-tab-panels>
             </cds-header-panel>


### PR DESCRIPTION
## Summary
- Adds a one-line `Version <ver> (YYYY-MM-DD)` display at the bottom of the admin Account switcher panel in `layout-internal.html`, sourced from the auto-configured Spring Boot `BuildProperties` bean (`springBoot { buildInfo() }` was already wired in `build.gradle.kts`).
- Bumps the project version from `1.2.1` to `1.3.0` in `gradle.properties`.
- Adds a small `.iko-version-line` rule in `main.css` using `var(--cds-spacing-*)` tokens (secondary text color, compact body font).

Closes [iko-issues#284](https://github.com/Integraal-Klant-en-Objectbeeld/iko-issues/issues/284).

## Test plan
- [x] `./gradlew spotlessApply` clean
- [x] `./gradlew classes` produces `build/resources/main/META-INF/build-info.properties` with `build.version=1.3.0` and a UTC `build.time`
- [x] Manual: `./gradlew bootRun`, open `/admin`, click the user/person icon in the header, confirm the line `Version 1.3.0 (<today's UTC date>)` appears at the bottom of the Account panel beneath the Snelkoppelingen list