### PR TITLE
feat: forward logged-in user email as x-gebruiker header on BRP wsGateway calls

### DIFF
--- a/doc/connectors/haalcentraal-brp-wsgateway.md
+++ b/doc/connectors/haalcentraal-brp-wsgateway.md
@@ -52,7 +52,7 @@ Other operations may be defined in newer versions of the BRP spec; inspect the O
 
 ## Trace log identifiers
 
-Both routes and the meaningful steps inside them carry human-readable `id` values so Camel trace logs and error messages are searchable. The connector route is `REFERENCE-connector` (becomes `connector:REFERENCE:<version>:REFERENCE-connector` after version-namespacing at load time); the endpoint-transform route is `REFERENCE-personen-transform`. Step IDs to watch for: `token-cache-lookup`, `if-token-not-cached`, `keycloak-client-credentials-post`, `extract-subject-token`, `keycloak-token-exchange-post`, `token-cache-store`, `brp-personen-post`. Trivial `setHeader`/`removeHeaders` steps are intentionally unnamed to keep traces concise.
+Both routes and the meaningful steps inside them carry human-readable `id` values so Camel trace logs and error messages are searchable. The connector route is `REFERENCE-connector` (becomes `connector:REFERENCE:<version>:REFERENCE-connector` after version-namespacing at load time); the endpoint-transform route is `REFERENCE-personen-transform`. Step IDs to watch for: `token-cache-lookup`, `if-token-not-cached`, `keycloak-client-credentials-post`, `extract-subject-token`, `keycloak-token-exchange-post`, `token-cache-store`, `set-x-gebruiker-header`, `brp-personen-post`. Trivial `setHeader`/`removeHeaders` steps are intentionally unnamed to keep traces concise.
 
 ## Token caching
 
@@ -189,6 +189,9 @@ Copy the connector code below and replace `REFERENCE` with the connector's tag (
                     simple: "${variable.brpRequestBody}"
               - removeHeaders:
                     pattern: "*"
+              - to:
+                    id: "set-x-gebruiker-header"
+                    uri: "bean:userHeaderProcessor?method=addEmailHeader"
               - setHeader:
                     name: "Authorization"
                     simple: "Bearer ${variable.accessToken}"
@@ -239,6 +242,7 @@ sequenceDiagram
         Cache-->>Conn: variable.accessToken = cached token
     end
     Conn->>Conn: restore body from variable.brpRequestBody
+    Conn->>Conn: setHeader x-gebruiker: <email> from SecurityContext
     Conn->>Conn: setHeader Authorization: Bearer <accessToken>
     Conn->>Conn: setHeader Content-Type / Accept
     Conn->>BRP: POST /personen via rest-openapi (body = JSON search request)
@@ -270,6 +274,8 @@ Identical in shape to the X-Api-Key BRP connector: a `choice/when` defaults `bur
 **Map key access in Simple vs Groovy** — The two `setBody` steps above use bracket notation `${variable.configProperties[clientId]}` because Camel's Simple language OGNL treats `.clientId` as a method invocation on the `LinkedHashMap` (which fails with `Method with name: clientId not found`). The `toD` URI lines further down are wrapped in `language:groovy:"..."` and so use the dot form `${variable.configProperties.tokenUrl}` because Groovy's `.` operator does Map-property access.
 
 **`setBody simple: "${variable.brpRequestBody}"`** — Restores the BRP search body that the endpoint-transform built. `removeHeaders pattern: "*"` immediately after clears the OAuth-related headers so they do not leak into the BRP request.
+
+**`to: "bean:userHeaderProcessor?method=addEmailHeader"`** — Invokes the `UserHeaderProcessor` Spring bean. The bean reads the `email` claim from the current authentication (`Jwt` principal for API callers such as GZAC, `OidcUser` for the admin UI) and sets it as the `x-gebruiker` HTTP header so the WS Gateway can attribute the call to the logged-in employee. When no email is available the step logs a warning and proceeds without the header rather than failing the request.
 
 **`setHeader Authorization: Bearer ${variable.accessToken}`** — Sets the bearer token for the BRP call.
 

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -167,4 +167,7 @@ class SecurityConfig {
 
     @Bean
     fun authRoute() = AuthRoute()
+
+    @Bean
+    fun userHeaderProcessor() = UserHeaderProcessor()
 }

--- a/src/main/kotlin/com/ritense/iko/security/UserHeaderProcessor.kt
+++ b/src/main/kotlin/com/ritense/iko/security/UserHeaderProcessor.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.security
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.apache.camel.Exchange
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.oauth2.jwt.Jwt
+
+class UserHeaderProcessor {
+
+    fun addEmailHeader(exchange: Exchange) {
+        val email = currentUserEmail()
+        if (email.isNullOrBlank()) {
+            logger.warn { "No email available on current authentication; skipping $X_GEBRUIKER_HEADER header" }
+            return
+        }
+        exchange.message.setHeader(X_GEBRUIKER_HEADER, email)
+    }
+
+    private fun currentUserEmail(): String? {
+        val principal = SecurityContextHolder.getContext().authentication?.principal ?: return null
+        return when (principal) {
+            is Jwt -> principal.getClaimAsString(EMAIL_CLAIM)
+            is OidcUser -> principal.userInfo?.claims?.get(EMAIL_CLAIM) as? String
+            else -> null
+        }
+    }
+
+    companion object {
+        const val X_GEBRUIKER_HEADER = "x-gebruiker"
+        private const val EMAIL_CLAIM = "email"
+        private val logger = KotlinLogging.logger {}
+    }
+}

--- a/src/test/resources/connectors/brp-wsgateway-template.yaml
+++ b/src/test/resources/connectors/brp-wsgateway-template.yaml
@@ -104,6 +104,9 @@
                     simple: "${variable.brpRequestBody}"
               - removeHeaders:
                     pattern: "*"
+              - to:
+                    id: "set-x-gebruiker-header"
+                    uri: "bean:userHeaderProcessor?method=addEmailHeader"
               - setHeader:
                     name: "Authorization"
                     simple: "Bearer ${variable.accessToken}"


### PR DESCRIPTION
## Summary
- Adds `UserHeaderProcessor`, a Camel-invokable Spring bean that reads the `email` claim from the current authentication principal (`Jwt` for API/GZAC bearer tokens, `OidcUser` for the admin UI) and sets it as `x-gebruiker` on the outgoing exchange. Falls back to a warn log + no header when no email is available, so background/unauthenticated flows are not broken.
- Wires the bean into the BRP wsGateway connector YAML right after the pre-BRP `removeHeaders *` so the header is only attached to the final BRP `personen` POST, not to the Keycloak token-exchange calls.
- Updates the connector reference doc (`doc/connectors/haalcentraal-brp-wsgateway.md`): YAML block, step-ID list, sequence diagram, and a paragraph describing the new step.

Driven by a working-session agreement with Thijs / Kim Meulenbroek: forward the logged-in employee's email so the WS Gateway can attribute calls without us having to merge multiple tokens.

## Test plan
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew test --tests "com.ritense.iko.mvc.model.validation.ValidConnectorCodeValidatorTest"` (confirms the modified YAML still validates)
- [ ] Manual: hit an ADP that uses the BRP wsGateway connector with a JWT containing an `email` claim, confirm the WS Gateway receives `x-gebruiker: <email>` (e.g. via the mock/nginx access log or BRP gateway logs).
- [ ] Manual: hit the same ADP with a token that has no `email` claim and confirm the request still completes (no header sent, warn line logged).