### PR TITLE
fix: namespace Camel route ids per connector version (#282)

### DIFF
--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -69,16 +69,19 @@ open class ConnectorService(
 
             // Namespace routeId and from URI with tag:version BEFORE adding to context
             routeBuilder.routeCollection.routes.forEach { routeDef ->
+                val originalRouteId = routeDef.id
+                val namespacedRouteId = "connector:${connector.tag}:${connector.version.value}:$originalRouteId"
                 routeDef.group(groupName)
+                routeDef.id = namespacedRouteId
                 with(routeDef.input) {
-                    id = "connector:${connector.tag}:${connector.version.value}:${routeDef.id}"
+                    id = namespacedRouteId
                     uri = namespaceUri(uri, connector.version.value)
                 }
             }
 
             // Pre-check for duplicate route IDs
             val existingRouteIds = camelContext.routes.map { it.routeId }.toSet()
-            val newRouteIds = routeBuilder.routeCollection.routes.map { it.input.id }.toSet()
+            val newRouteIds = routeBuilder.routeCollection.routes.map { it.id }.toSet()
             val duplicates = newRouteIds.filter { it in existingRouteIds }
             if (duplicates.isNotEmpty()) {
                 logger.debug { "Routes already loaded for connector ${connector.tag} v${connector.version}, skipping" }

--- a/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/service/ConnectorServiceTest.kt
@@ -16,9 +16,16 @@
 
 package com.ritense.iko.connectors.service
 
+import com.ritense.iko.connectors.domain.Connector
+import com.ritense.iko.connectors.domain.Version
+import org.apache.camel.impl.DefaultCamelContext
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import java.util.UUID
 
 class ConnectorServiceTest {
 
@@ -69,5 +76,104 @@ class ConnectorServiceTest {
             )
             assertThat(result).isEqualTo("direct:iko:connector:my-tag:1.0.0")
         }
+    }
+
+    @Nested
+    inner class LoadConnectorRoutes {
+
+        private lateinit var camelContext: DefaultCamelContext
+        private lateinit var service: ConnectorService
+
+        @BeforeEach
+        fun setUp() {
+            camelContext = DefaultCamelContext()
+            camelContext.start()
+            service = ConnectorService(
+                connectorRepository = mock(),
+                connectorInstanceRepository = mock(),
+                connectorEndpointRepository = mock(),
+                connectorEndpointRoleRepository = mock(),
+                camelContext = camelContext,
+            )
+        }
+
+        @AfterEach
+        fun tearDown() {
+            camelContext.stop()
+        }
+
+        @Test
+        fun `route ids are namespaced with tag and version`() {
+            val connector = connector(tag = "test", version = "1.0.0")
+
+            service.loadConnectorRoutes(connector)
+
+            val routeIds = camelContext.routes.map { it.routeId }
+            assertThat(routeIds).contains(
+                "connector:test:1.0.0:brp-wsgateway-personen",
+                "connector:test:1.0.0:brp-wsgateway-personen-transform",
+            )
+        }
+
+        @Test
+        fun `loading two versions of same connector coexists without route id collision`() {
+            val v100 = connector(tag = "test", version = "1.0.0")
+            val v101 = connector(tag = "test", version = "1.0.1")
+
+            service.loadConnectorRoutes(v100)
+            service.loadConnectorRoutes(v101)
+
+            val routeIds = camelContext.routes.map { it.routeId }
+            assertThat(routeIds).contains(
+                "connector:test:1.0.0:brp-wsgateway-personen",
+                "connector:test:1.0.0:brp-wsgateway-personen-transform",
+                "connector:test:1.0.1:brp-wsgateway-personen",
+                "connector:test:1.0.1:brp-wsgateway-personen-transform",
+            )
+
+            assertThat(camelContext.hasEndpoint("direct://iko:endpoint:transform:test:1.0.0.Personen")).isNotNull()
+            assertThat(camelContext.hasEndpoint("direct://iko:endpoint:transform:test:1.0.1.Personen")).isNotNull()
+        }
+
+        @Test
+        fun `loading the same connector twice is idempotent`() {
+            val connector = connector(tag = "test", version = "1.0.0")
+
+            service.loadConnectorRoutes(connector)
+            val routeCountAfterFirst = camelContext.routes.size
+
+            service.loadConnectorRoutes(connector)
+
+            assertThat(camelContext.routes.size).isEqualTo(routeCountAfterFirst)
+        }
+
+        private fun connector(tag: String, version: String): Connector = Connector(
+            id = UUID.randomUUID(),
+            name = tag,
+            tag = tag,
+            version = Version(version),
+            connectorCode = CONNECTOR_YAML.trimIndent(),
+        )
+    }
+
+    companion object {
+        // Minimal YAML with one connector route and one endpoint transform route.
+        // Route ids match what's seen in the issue #282 logs.
+        private const val CONNECTOR_YAML = """
+            - route:
+                id: brp-wsgateway-personen
+                from:
+                  uri: "direct:iko:connector:test"
+                  steps:
+                    - setBody:
+                        constant: '{}'
+            - route:
+                id: brp-wsgateway-personen-transform
+                from:
+                  uri: "direct:iko:endpoint:transform:test.Personen"
+                  steps:
+                    - setBody:
+                        constant: '{}'
+        """
     }
 }


### PR DESCRIPTION
## Summary
- Fixes [iko-issues#282](https://github.com/Integraal-Klant-en-Objectbeeld/iko-issues/issues/282): activating a new connector version broke ADPs still pointing at the previous version.
- `ConnectorService.loadConnectorRoutes` now namespaces `routeDef.id` (the Camel route id) in addition to the `from` endpoint id and URI, so multiple versions of the same connector tag can coexist in the Camel context without route-id collisions.
- The duplicate-id pre-check now compares route id to route id (previously compared `existing.routeId` against `new.input.id`, which never intersected).

## Root cause
The `from` URI and `input.id` were namespaced per `<tag>:<version>`, but `routeDef.routeId` was left as declared in the YAML. When v1.0.1 was activated, Camel encountered a route id already loaded from v1.0.0, stopped/shutdown the v1.0.0 route, and replaced it. ADPs still linked to a v1.0.0 instance dispatched (correctly, by their linked version) to `direct:iko:endpoint:transform:test:1.0.0.<op>`, which now had no consumer. The failure surfaced downstream as the `ResponseFacade … recycled` write error from `SpringBootPlatformHttpConsumer`.

See `thoughts/shared/research/2026-06-02-issue-282-adp-connector-version-coexistence.md` for the full analysis.

## Test plan
- [x] `./gradlew spotlessCheck`
- [x] `./gradlew test` — full unit suite passes
- [x] New unit tests in `ConnectorServiceTest.LoadConnectorRoutes` cover:
  - route ids are namespaced as `connector:<tag>:<version>:<original>`
  - two versions of the same tag coexist in one Camel context without collision (both `from` URIs remain registered)
  - loading the same connector twice is idempotent (existing duplicate-id short-circuit still works)
- [ ] Manual repro of issue #282:
  - active ADP `brp` linked to TEST v1.0.0
  - bump TEST to v1.0.1
  - confirm no `Stopped brp-wsgateway-personen-transform` line during activation
  - `GET /aggregated-data-profiles/brp` still returns the expected body