### PR TITLE
fix: validate sourceToEndpointMapping jq at form binding

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/AddRelationForm.kt
@@ -30,6 +30,7 @@ data class AddRelationForm(
     val connectorInstanceId: UUID,
     val connectorEndpointId: UUID,
     @field:NotBlank(message = "Please provide a mapping.")
+    @field:ValidTransform
     val sourceToEndpointMapping: String,
     @field:NotBlank(message = "Please define a transform expression.")
     @field:ValidTransform

--- a/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/EditRelationForm.kt
@@ -31,6 +31,7 @@ data class EditRelationForm(
     override val id: UUID,
     override val sourceId: UUID,
     @field:NotBlank(message = "Please provide a mapping.")
+    @field:ValidTransform
     val sourceToEndpointMapping: String,
     @field:NotBlank(message = "Please provide a transform expression.")
     @field:ValidTransform


### PR DESCRIPTION
## Summary
- Add `@ValidTransform` to `sourceToEndpointMapping` on `AddRelationForm` and `EditRelationForm`.
- Previously this field carried only `@NotBlank`, so an invalid jq expression bypassed bean validation and threw `IllegalArgumentException` from the `RelationEndpointTransform` domain constructor — surfacing as an HTTP 500 instead of a form field error.
- Now an unparseable jq expression is reported as a `BindingResult` field error and re-rendered in the relation form fragment, consistent with `resultTransform`.

## Test plan
- [ ] Submit a relation add/edit form with an invalid jq in the mapping field → expect inline field validation error (not 500).
- [ ] Submit with valid jq → expect normal save.
- [ ] `./gradlew test`