### PR TITLE
feat: handle connector route load Result and enforce unique connector reference

### DIFF
--- a/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
+++ b/src/main/kotlin/com/ritense/iko/aggregateddataprofile/service/AggregatedDataProfileService.kt
@@ -73,7 +73,7 @@ open class AggregatedDataProfileService(
         val requiredConnectors = routeDependencyService.resolveConnectorDependencies(aggregatedDataProfile)
         for (connector in requiredConnectors) {
             if (!routeDependencyService.isConnectorRouteLoaded(connector)) {
-                connectorService.loadConnectorRoutes(connector)
+                connectorService.loadConnectorRoutes(connector).getOrThrow()
             }
         }
         camelContext.addRoutes(

--- a/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/autoconfiguration/ConnectorConfiguration.kt
@@ -108,12 +108,13 @@ class ConnectorConfiguration(
         val connectorService = event.applicationContext.getBean(ConnectorService::class.java)
         // Only load active connectors at startup
         connectorRepository.findAllByIsActiveTrue().forEach { connector ->
-            try {
-                connectorService.loadConnectorRoutes(connector)
-                logger.debug { "Loaded routes for active connector: ${connector.tag} v${connector.version}" }
-            } catch (e: Exception) {
-                logger.error(e) { "Failed to load connector ${connector.tag} v${connector.version}" }
-            }
+            connectorService.loadConnectorRoutes(connector)
+                .onSuccess {
+                    logger.debug { "Loaded routes for active connector: ${connector.tag} v${connector.version}" }
+                }
+                .onFailure { e ->
+                    logger.error(e) { "Failed to load connector ${connector.tag} v${connector.version}" }
+                }
         }
     }
 

--- a/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/repository/ConnectorRepository.kt
@@ -26,6 +26,8 @@ import org.springframework.data.repository.query.Param
 import java.util.UUID
 
 interface ConnectorRepository : JpaRepository<Connector, UUID> {
+    fun existsByTag(tag: String): Boolean
+
     fun findByTagAndIsActiveTrue(tag: String): Connector?
 
     @Query("SELECT c FROM Connector c WHERE c.tag = :tag AND c.version.value = :version")

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -137,6 +137,48 @@ open class ConnectorService(
     }
 
     /**
+     * Creates a new active connector, loading its routes before persisting so a broken
+     * connector is never saved. On route-load failure any partial routes are removed and
+     * the failure is returned without persisting.
+     */
+    @Transactional
+    open fun createConnector(name: String, reference: String, connectorCode: String): Result<Connector> = runCatching {
+        val connector = Connector(
+            id = UUID.randomUUID(),
+            name = name,
+            tag = reference,
+            connectorCode = connectorCode,
+            isActive = true,
+        )
+        loadConnectorRoutes(connector).getOrElse { e ->
+            removeConnectorRoutes(connector)
+            throw e
+        }
+        connectorRepository.save(connector)
+        connector
+    }
+
+    /**
+     * Updates a connector's code, reloading its routes before persisting. On route-load
+     * failure the previous code and routes are restored and the broken code is never saved.
+     */
+    @Transactional
+    open fun updateConnectorCode(connector: Connector, newCode: String): Result<Connector> = runCatching {
+        validateConnectorCode(newCode, connector.tag)
+        val previousCode = connector.connectorCode
+        connector.connectorCode = newCode
+        if (connector.isActive) {
+            reloadConnectorRoutes(connector).getOrElse { e ->
+                connector.connectorCode = previousCode
+                reloadConnectorRoutes(connector)
+                throw e
+            }
+        }
+        connectorRepository.save(connector)
+        connector
+    }
+
+    /**
      * Removes all routes belonging to a connector using route groups.
      */
     open fun removeConnectorRoutes(connector: Connector) {

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -48,26 +48,22 @@ open class ConnectorService(
      * Pattern: Parse YAML → Modify RouteDefinitions → Add via addRoutes()
      * This matches the existing AggregatedDataProfileService pattern.
      */
-    open fun loadConnectorRoutes(connector: Connector) {
+    open fun loadConnectorRoutes(connector: Connector): Result<Unit> = runCatching {
         val groupName = "group:connector:${connector.id}"
 
-        // Step 1: Create resource from YAML (filename must end in .yaml)
         val resource = ResourceHelper.fromString(
             "${connector.tag}.yaml",
             connector.connectorCode,
         )
 
-        // Step 2: Parse YAML to RoutesBuilder objects WITHOUT loading into context
         val loader = PluginHelper.getRoutesLoader(camelContext)
         val builders = loader.findRoutesBuilders(listOf(resource))
 
-        // Step 3: For each builder, configure it, modify route definitions, then add to context
         builders.forEach { builder ->
             val routeBuilder = builder as RouteBuilder
             routeBuilder.setCamelContext(camelContext)
             routeBuilder.configure()
 
-            // Namespace routeId and from URI with tag:version BEFORE adding to context
             routeBuilder.routeCollection.routes.forEach { routeDef ->
                 val originalRouteId = routeDef.id
                 val namespacedRouteId = "connector:${connector.tag}:${connector.version.value}:$originalRouteId"
@@ -79,16 +75,14 @@ open class ConnectorService(
                 }
             }
 
-            // Pre-check for duplicate route IDs
             val existingRouteIds = camelContext.routes.map { it.routeId }.toSet()
             val newRouteIds = routeBuilder.routeCollection.routes.map { it.id }.toSet()
             val duplicates = newRouteIds.filter { it in existingRouteIds }
             if (duplicates.isNotEmpty()) {
                 logger.debug { "Routes already loaded for connector ${connector.tag} v${connector.version}, skipping" }
-                return
+                return@runCatching
             }
 
-            // Add routes using standard CamelContext.addRoutes() - same pattern as AggregatedDataProfileService
             camelContext.addRoutes(routeBuilder)
         }
 
@@ -137,9 +131,9 @@ open class ConnectorService(
         }
     }
 
-    open fun reloadConnectorRoutes(connector: Connector) {
+    open fun reloadConnectorRoutes(connector: Connector): Result<Unit> {
         removeConnectorRoutes(connector)
-        loadConnectorRoutes(connector)
+        return loadConnectorRoutes(connector)
     }
 
     /**
@@ -199,7 +193,7 @@ open class ConnectorService(
         // Activate new version and load routes (coexists with old due to version-namespaced URIs)
         connectorToActivate.isActive = true
         connectorRepository.save(connectorToActivate)
-        loadConnectorRoutes(connectorToActivate)
+        loadConnectorRoutes(connectorToActivate).getOrThrow()
         logger.debug { "Activated Connector ${connectorToActivate.tag} v${connectorToActivate.version}" }
     }
 

--- a/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/service/ConnectorService.kt
@@ -64,6 +64,10 @@ open class ConnectorService(
             routeBuilder.setCamelContext(camelContext)
             routeBuilder.configure()
 
+            require(routeBuilder.routeCollection.routes.isNotEmpty()) {
+                "Connector code for [${connector.tag}] v${connector.version.value} contains no route"
+            }
+
             routeBuilder.routeCollection.routes.forEach { routeDef ->
                 val originalRouteId = routeDef.id
                 val namespacedRouteId = "connector:${connector.tag}:${connector.version.value}:$originalRouteId"
@@ -84,6 +88,9 @@ open class ConnectorService(
             }
 
             camelContext.addRoutes(routeBuilder)
+            newRouteIds.forEach { routeId ->
+                logger.info { "Loaded connector route [$routeId] for connector [${connector.tag}] v${connector.version.value}" }
+            }
         }
 
         logger.debug { "Loaded ${builders.size} route builder(s) for connector [${connector.tag}] with group [$groupName]" }

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -36,6 +36,7 @@ import com.ritense.iko.mvc.model.connector.ConnectorInstanceConfigEditForm
 import com.ritense.iko.mvc.model.connector.ConnectorInstanceEditForm
 import com.ritense.iko.mvc.model.connector.ConnectorInstanceRolesEditForm
 import com.ritense.iko.security.SecurityContextHelper
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
@@ -235,6 +236,24 @@ class ConnectorController(
         connectorRepository.save(connector)
         if (connector.isActive) {
             connectorService.reloadConnectorRoutes(connector)
+                .onFailure { e ->
+                    logger.error(e) { "Failed to reload routes for connector ${connector.tag} v${connector.version}" }
+                    bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Failed to load connector routes")
+                }
+        }
+
+        if (bindingResult.hasErrors()) {
+            httpServletResponse.setHeader("HX-Retarget", "#connector-code")
+            httpServletResponse.setHeader("HX-Reswap", "outerHTML")
+            httpServletResponse.setHeader("HX-Trigger-After-Settle", "reinitAceEditors")
+
+            return ModelAndView(
+                "fragments/internal/connector/details-page-connector :: connector-code",
+                mapOf(
+                    "connector" to form,
+                    "errors" to bindingResult,
+                ),
+            )
         }
 
         httpServletResponse.setHeader("HX-Retarget", "#connector-code")
@@ -309,7 +328,23 @@ class ConnectorController(
             )
 
         connectorRepository.save(connector)
+
         connectorService.loadConnectorRoutes(connector)
+            .onFailure { e ->
+                logger.error(e) { "Failed to load routes for new connector ${connector.tag}" }
+                connectorRepository.delete(connector)
+                bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Failed to load connector routes")
+            }
+
+        if (bindingResult.hasErrors()) {
+            return ModelAndView(
+                "fragments/internal/connector/form-create-connector :: form",
+                mapOf(
+                    "connector" to form,
+                    "errors" to bindingResult,
+                ),
+            )
+        }
 
         httpServletResponse.setHeader("HX-Push-Url", "/admin/connectors/${connector.id}")
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
@@ -878,6 +913,8 @@ class ConnectorController(
     }
 
     companion object {
+        private val logger = KotlinLogging.logger {}
+
         fun hxRequest(
             isHxRequest: Boolean,
             template: String,

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -209,58 +209,16 @@ class ConnectorController(
         connector.ensureDraft()
 
         if (!bindingResult.hasErrors()) {
-            try {
-                connectorService.validateConnectorCode(form.connectorCode, connector.tag)
-            } catch (e: Exception) {
-                bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Invalid connector code")
-            }
-        }
-
-        if (bindingResult.hasErrors()) {
-            httpServletResponse.setHeader("HX-Retarget", "#connector-code")
-            httpServletResponse.setHeader("HX-Reswap", "outerHTML")
-            // After-Settle: fires once the swapped content is in the DOM so the
-            // editor element exists when initAllEditors runs.
-            httpServletResponse.setHeader("HX-Trigger-After-Settle", "reinitAceEditors")
-
-            return ModelAndView(
-                "fragments/internal/connector/details-page-connector :: connector-code",
-                mapOf(
-                    "connector" to form,
-                    "errors" to bindingResult,
-                ),
-            )
-        }
-
-        val previousCode = connector.connectorCode
-        connector.connectorCode = form.connectorCode
-        if (connector.isActive) {
-            // Load the new routes before persisting; only commit the code once Camel accepts it.
-            connectorService.reloadConnectorRoutes(connector)
+            connectorService.updateConnectorCode(connector, form.connectorCode)
                 .onFailure { e ->
-                    logger.error(e) { "Failed to reload routes for connector ${connector.tag} v${connector.version}" }
-                    // Restore the previous working routes and discard the broken code (never persisted).
-                    connector.connectorCode = previousCode
-                    connectorService.reloadConnectorRoutes(connector)
-                    bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Failed to load connector routes")
+                    logger.error(e) { "Failed to update connector ${connector.tag} v${connector.version}" }
+                    bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Invalid connector code")
                 }
         }
 
         if (bindingResult.hasErrors()) {
-            httpServletResponse.setHeader("HX-Retarget", "#connector-code")
-            httpServletResponse.setHeader("HX-Reswap", "outerHTML")
-            httpServletResponse.setHeader("HX-Trigger-After-Settle", "reinitAceEditors")
-
-            return ModelAndView(
-                "fragments/internal/connector/details-page-connector :: connector-code",
-                mapOf(
-                    "connector" to form,
-                    "errors" to bindingResult,
-                ),
-            )
+            return connectorCodeError(form, bindingResult, httpServletResponse)
         }
-
-        connectorRepository.save(connector)
 
         httpServletResponse.setHeader("HX-Retarget", "#connector-code")
         httpServletResponse.setHeader("HX-Trigger", "close-modal")
@@ -271,6 +229,26 @@ class ConnectorController(
             "fragments/internal/connector/details-page-connector :: connector-code",
             mapOf(
                 "connector" to connector.toDTO(),
+            ),
+        )
+    }
+
+    private fun connectorCodeError(
+        form: ConnectorEditForm,
+        bindingResult: BindingResult,
+        httpServletResponse: HttpServletResponse,
+    ): ModelAndView {
+        httpServletResponse.setHeader("HX-Retarget", "#connector-code")
+        httpServletResponse.setHeader("HX-Reswap", "outerHTML")
+        // After-Settle: fires once the swapped content is in the DOM so the
+        // editor element exists when initAllEditors runs.
+        httpServletResponse.setHeader("HX-Trigger-After-Settle", "reinitAceEditors")
+
+        return ModelAndView(
+            "fragments/internal/connector/details-page-connector :: connector-code",
+            mapOf(
+                "connector" to form,
+                "errors" to bindingResult,
             ),
         )
     }
@@ -324,21 +302,9 @@ class ConnectorController(
             )
         }
 
-        val connector =
-            Connector(
-                id = UUID.randomUUID(),
-                name = form.name,
-                tag = form.reference,
-                connectorCode = form.connectorCode,
-                isActive = true,
-            )
-
-        connectorRepository.save(connector)
-
-        connectorService.loadConnectorRoutes(connector)
+        val result = connectorService.createConnector(form.name, form.reference, form.connectorCode)
             .onFailure { e ->
-                logger.error(e) { "Failed to load routes for new connector ${connector.tag}" }
-                connectorRepository.delete(connector)
+                logger.error(e) { "Failed to create connector ${form.reference}" }
                 bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Failed to load connector routes")
             }
 
@@ -352,6 +318,7 @@ class ConnectorController(
             )
         }
 
+        val connector = result.getOrThrow()
         httpServletResponse.setHeader("HX-Push-Url", "/admin/connectors/${connector.id}")
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
         httpServletResponse.setHeader("HX-Trigger", "close-modal")

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/ConnectorController.kt
@@ -232,12 +232,16 @@ class ConnectorController(
             )
         }
 
+        val previousCode = connector.connectorCode
         connector.connectorCode = form.connectorCode
-        connectorRepository.save(connector)
         if (connector.isActive) {
+            // Load the new routes before persisting; only commit the code once Camel accepts it.
             connectorService.reloadConnectorRoutes(connector)
                 .onFailure { e ->
                     logger.error(e) { "Failed to reload routes for connector ${connector.tag} v${connector.version}" }
+                    // Restore the previous working routes and discard the broken code (never persisted).
+                    connector.connectorCode = previousCode
+                    connectorService.reloadConnectorRoutes(connector)
                     bindingResult.rejectValue("connectorCode", "invalid", e.message ?: "Failed to load connector routes")
                 }
         }
@@ -255,6 +259,8 @@ class ConnectorController(
                 ),
             )
         }
+
+        connectorRepository.save(connector)
 
         httpServletResponse.setHeader("HX-Retarget", "#connector-code")
         httpServletResponse.setHeader("HX-Trigger", "close-modal")

--- a/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/connector/ConnectorCreateForm.kt
@@ -16,15 +16,18 @@
 
 package com.ritense.iko.mvc.model.connector
 
+import com.ritense.iko.mvc.model.validation.UniqueConnector
+import com.ritense.iko.mvc.model.validation.UniqueConnectorCheck
 import com.ritense.iko.mvc.model.validation.ValidConnectorCode
 import jakarta.validation.constraints.NotBlank
 
+@UniqueConnectorCheck
 data class ConnectorCreateForm(
     @field:NotBlank(message = "Please provide a name.")
     val name: String,
     @field:NotBlank(message = "Please provide a reference.")
-    val reference: String,
+    override val reference: String,
     @field:NotBlank(message = "Connector code must not be empty. Refer to the documentation for connector code requirements..")
     @field:ValidConnectorCode
     val connectorCode: String,
-)
+) : UniqueConnector

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnector.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnector.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.mvc.model.validation
+
+interface UniqueConnector {
+    val reference: String
+}

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnectorCheck.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnectorCheck.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.mvc.model.validation
+
+import jakarta.validation.Constraint
+import jakarta.validation.Payload
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Constraint(validatedBy = [UniqueConnectorValidator::class])
+annotation class UniqueConnectorCheck(
+    val message: String = "Reference already exists/in use, please choose another.",
+    val groups: Array<KClass<*>> = [],
+    val payload: Array<KClass<out Payload>> = [],
+)

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnectorValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueConnectorValidator.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.mvc.model.validation
+
+import com.ritense.iko.connectors.repository.ConnectorRepository
+import jakarta.validation.ConstraintValidator
+import jakarta.validation.ConstraintValidatorContext
+import org.springframework.stereotype.Component
+
+@Component
+class UniqueConnectorValidator(
+    private val connectorRepository: ConnectorRepository,
+) : ConstraintValidator<UniqueConnectorCheck, UniqueConnector> {
+    override fun isValid(
+        form: UniqueConnector,
+        context: ConstraintValidatorContext,
+    ): Boolean {
+        if (form.reference.isBlank()) return false
+
+        val exists = connectorRepository.existsByTag(form.reference)
+        if (exists) {
+            context.disableDefaultConstraintViolation()
+            context
+                .buildConstraintViolationWithTemplate("Reference already exists/in use, please choose another.")
+                .addPropertyNode("reference")
+                .addConstraintViolation()
+        }
+
+        return !exists
+    }
+}

--- a/src/main/resources/static/js/admin-ui.js
+++ b/src/main/resources/static/js/admin-ui.js
@@ -425,6 +425,34 @@ document.body.addEventListener("click", function (event) {
 });
 
 // ---------------------------------------------------------------------------
+// connector/form-create-connector.html: keep the connector code in sync with
+// the reference field. The default code carries a `direct:iko:connector:CHANGEME`
+// placeholder; as the user types the reference, rewrite the token so they don't
+// have to edit the YAML by hand. Tracks the last-applied token per editor.
+// ---------------------------------------------------------------------------
+document.body.addEventListener("input", function (event) {
+    var field = event.target;
+    if (!field || field.getAttribute("name") !== "reference") return;
+    var editorEl = document.getElementById("connectorCodeEditor");
+    if (!editorEl || !editorEl._editor) return;
+
+    var prefix = "direct:iko:connector:";
+    var oldToken =
+        editorEl._refToken != null ? editorEl._refToken : "CHANGEME";
+    var newToken = field.value || "";
+    if (newToken === oldToken) return;
+
+    var escaped = oldToken.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    var pattern = new RegExp(escaped ? prefix + escaped : prefix, "g");
+    var code = editorEl._editor.getValue();
+    var updated = code.replace(pattern, prefix + newToken);
+    if (updated !== code) {
+        editorEl._editor.setValue(updated, -1);
+    }
+    editorEl._refToken = newToken;
+});
+
+// ---------------------------------------------------------------------------
 // logging/list.html: toggle filter panel button
 // ---------------------------------------------------------------------------
 document.body.addEventListener("click", function (event) {


### PR DESCRIPTION
## Summary
- Propagate `Result<Unit>` from `ConnectorService.loadConnectorRoutes` at every call site so route-load failures surface instead of being swallowed.
- `reloadConnectorRoutes` now returns `Result`; `activateVersion` and ADP `loadRoute` fail fast via `getOrThrow` (rolling back their `@Transactional` work); startup loader uses `onSuccess`/`onFailure` instead of a dead try/catch; `ConnectorController` create/edit reject the form (and roll back the saved row on create) when load fails.
- `loadConnectorRoutes` now rejects connector code that parses to no route (`require` on the route builder's routes → `Result.failure`), and info-logs each route id on successful load.
- Add `UniqueConnector` validation (interface + `UniqueConnectorCheck` annotation + `UniqueConnectorValidator` backed by `ConnectorRepository.existsByTag`), applied to `ConnectorCreateForm`, mirroring `UniqueAggregatedDataProfile`.
- Create form UX: typing the reference field rewrites the `direct:iko:connector:CHANGEME` placeholder in the connector code editor live (CSP-safe delegated listener in `admin-ui.js`), so the route id no longer needs manual editing.

## Test plan
- [ ] `./gradlew test`
- [ ] Create connector with duplicate reference → form rejected with "Reference already exists/in use".
- [ ] Create/activate connector with broken YAML → failure surfaced, no orphan active row/routes.
- [ ] Create/activate connector whose code defines no route → load fails, form rejected.
- [ ] Create form: type reference → `id`/`uri` route lines update from CHANGEME to the reference value.