### PR TITLE
fix: avoid passing promise rejection to logout in session timeout

### DIFF
--- a/src/main/resources/static/js/session-timeout.js
+++ b/src/main/resources/static/js/session-timeout.js
@@ -117,7 +117,9 @@
                         logout();
                     }
                 })
-                .catch(logout);
+                .catch(function () {
+                    logout();
+                });
         }
 
         document


### PR DESCRIPTION
## Summary
- Fix `TypeError: event.preventDefault is not a function` in `session-timeout.js`
- `continueSession`'s `pingServer().catch(logout)` passed the promise rejection reason (an Error) as the `event` arg to `logout`, so `event.preventDefault()` threw
- Wrap the catch handler so `logout()` is called with no argument

## Test plan
- [x] Trigger session timeout warning modal, click Continue while server ping fails (e.g. offline) → logs out cleanly without console error
- [x] Normal Continue still extends session