### PR TITLE
feat: actuator on port 9090 with health probes and unsecured prometheus

### DIFF
--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -34,11 +34,13 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority
 import org.springframework.security.oauth2.server.resource.authentication.ExpressionJwtGrantedAuthoritiesConverter
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository
 import org.springframework.security.web.csrf.CsrfFilter
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler
 import org.springframework.security.web.header.HeaderWriterFilter
 import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter.ReferrerPolicy
+import org.springframework.security.web.util.matcher.AnyRequestMatcher
 import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher
 
 internal const val ADMIN_CSP_TEMPLATE =
@@ -58,32 +60,6 @@ internal const val ADMIN_CSP_TEMPLATE =
 @EnableWebSecurity
 @Configuration
 class SecurityConfig {
-    @Order(Ordered.HIGHEST_PRECEDENCE)
-    @Bean
-    fun actuatorSecurityFilterChain(
-        http: HttpSecurity,
-        jwtAuthenticationConverter: JwtAuthenticationConverter,
-    ): SecurityFilterChain {
-        http
-            .securityMatcher("/actuator/**")
-            .oauth2Login { oauth2 -> oauth2.disable() }
-            .oauth2ResourceServer { oauth2 ->
-                oauth2.jwt { jwt ->
-                    jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)
-                }
-            }.sessionManagement { session ->
-                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-            }.authorizeHttpRequests { authorize ->
-                authorize
-                    .requestMatchers("/actuator/health", "/actuator/health/**", "/actuator/info")
-                    .permitAll()
-                    .anyRequest()
-                    .hasAnyAuthority("ROLE_ADMIN")
-            }
-
-        return http.build()
-    }
-
     @Order(Ordered.LOWEST_PRECEDENCE - 1000)
     @Bean
     fun apiSecurityFilterChain(
@@ -180,6 +156,10 @@ class SecurityConfig {
                 ex.defaultAuthenticationEntryPointFor(
                     HtmxAuthenticationEntryPoint(),
                     RequestHeaderRequestMatcher("Hx-Request"),
+                )
+                ex.defaultAuthenticationEntryPointFor(
+                    LoginUrlAuthenticationEntryPoint("/oauth2/authorization/keycloak"),
+                    AnyRequestMatcher.INSTANCE,
                 )
             }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,6 +113,8 @@ management:
             show-details: always
             probes:
                 enabled: true
+        info:
+            access: read-only
         prometheus:
             access: read-only
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,16 +98,23 @@ spring:
                     authorities-claim-name: "[resource_access][iko][roles]"
 
 management:
+    server:
+        port: 9090
     endpoints:
         web:
             exposure:
                 include: "health,info,prometheus"
             base-path: /actuator
+        access:
+            default: none
     endpoint:
         health:
-            show-details: when_authorized
+            access: read-only
+            show-details: always
+            probes:
+                enabled: true
         prometheus:
-            enabled: true
+            access: read-only
 
 info:
     app:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -33,6 +33,10 @@ logging:
         com.ritense.iko: DEBUG
         org.springframework.security: DEBUG
 
+management:
+    server:
+        port: 0
+
 camel:
     main:
         tracing: true # for debugging


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/tasks/019ed505-cbf0-774a-a7da-21bbd26a5c1b/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019ed505-cbf0-774a-a7da-21bbd26a5c1b) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019ed50c-83d3-78b1-a31b-41d244553473)

## What problems was I solving

Spring Boot Actuator was served on the main application port (8080), alongside the API and admin UI. Guarding it required a dedicated `actuatorSecurityFilterChain` at `HIGHEST_PRECEDENCE` with its own JWT resource-server wiring — security concerns mixed onto a single port. Operationally we want metrics scraping and Kubernetes probes to hit a separate, internal management port rather than the public app port.

After this PR:
- Actuator runs on its own management port **9090**, isolated from the app port.
- The bespoke actuator security filter chain is gone — port isolation replaces per-path security.
- Endpoint access is **deny-by-default** (`management.endpoints.access.default: none`); `health`, `info`, and `prometheus` are each explicitly granted **read-only** access.
- Health **probes** (`/actuator/health/liveness`, `/readiness`) are enabled with `show-details: always`.
- Prometheus is exposed **without auth** for scraping, which is safe because it sits on the internal-only management port.

## What user-facing changes did I ship

- [src/main/resources/application.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d) - Actuator on port 9090; `access.default: none` with explicit read-only for health, info, prometheus; health probes enabled.
- [src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-94a779e45249ae101a181ecc2bafc16bf411289964f6e164d44ecc54a3a79258) - Removed the actuator security filter chain; added an explicit Keycloak login redirect for non-HTMX unauthenticated admin requests.
- [src/test/resources/application-test.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-3d17508f6ed3b2bf957c725741cde10edeb229b40b8c3cecf57e7dc5ce78ede6) - Management server bound to a random free port (`0`) in tests.

## How I implemented it

### Configuration changes
- [application.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d) - Added `management.server.port: 9090`. Kept `exposure.include: health,info,prometheus`, set `endpoints.access.default: none`, and explicitly granted `access: read-only` on `health`, `info`, and `prometheus`. Under `endpoint.health`, set `show-details: always` and `probes.enabled: true`; dropped the standalone `prometheus.enabled` block (exposure include is sufficient).
- [application-test.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-3d17508f6ed3b2bf957c725741cde10edeb229b40b8c3cecf57e7dc5ce78ede6) - Set `management.server.port: 0` so the test context binds a random free port and avoids collisions with a fixed 9090.

### Backend / security changes
- [SecurityConfig.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-94a779e45249ae101a181ecc2bafc16bf411289964f6e164d44ecc54a3a79258) - Deleted the entire `@Order(Ordered.HIGHEST_PRECEDENCE)` `actuatorSecurityFilterChain` bean (`securityMatcher("/actuator/**")` + stateless JWT + `ROLE_ADMIN`). With actuator on its own port, the app-port chains never see `/actuator`, so the bean was dead code.
- [SecurityConfig.kt admin chain](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/184/files#diff-94a779e45249ae101a181ecc2bafc16bf411289964f6e164d44ecc54a3a79258) - Added a second `defaultAuthenticationEntryPointFor` using `LoginUrlAuthenticationEntryPoint("/oauth2/authorization/keycloak")` matched by `AnyRequestMatcher.INSTANCE`, so non-HTMX (plain browser) unauthenticated requests get a deterministic redirect to Keycloak login. New imports: `LoginUrlAuthenticationEntryPoint`, `AnyRequestMatcher`.

### Commits
- `be68513` — actuator on 9090, security chain removed, probes enabled.
- `9a8b9ea` — explicit read-only access for the `info` endpoint (required because access defaults to none).

## Deviations from the plan

No plan file found in the task directory (only `ticket.md`). The implementation matches the ticket: actuator on port 9090, old actuator security configurer removed, health probes enabled and read-only, prometheus exposed unsecured. Access model went one step stricter than the ticket wording — deny-by-default with per-endpoint read-only grants rather than a blanket read-only default.

## How to verify it

### Manual Testing
- [ ] Run `./gradlew bootRun` (with `docker compose up -d`).
- [ ] `curl localhost:9090/actuator/health` → returns `UP` with details.
- [ ] `curl localhost:9090/actuator/health/liveness` and `/readiness` → return `UP`.
- [ ] `curl localhost:9090/actuator/info` → returns info, read-only.
- [ ] `curl localhost:9090/actuator/prometheus` → returns metrics, no auth.
- [ ] `curl localhost:8080/actuator/health` → no longer served on the app port.
- [ ] Hit `localhost:8080/admin` unauthenticated in a browser → redirected to Keycloak login.

### Automated Tests
```bash
./gradlew build
./gradlew test
```

## Description for the changelog

Run Actuator on a dedicated management port (9090) with deny-by-default access, explicit read-only health/info/prometheus, Kubernetes health probes, and an unsecured Prometheus endpoint; remove the bespoke actuator security filter chain.
