### PR TITLE
fix: expose window.ikoLogout for session-timeout auto-logout

### DIFF
--- a/src/main/resources/static/js/admin-ui.js
+++ b/src/main/resources/static/js/admin-ui.js
@@ -54,12 +54,10 @@ document.body.addEventListener("close-modal", function () {
 });
 
 // ---------------------------------------------------------------------------
-// Logout — triggered by id="logout-link"
+// Logout — exposed as window.ikoLogout (also used by session-timeout.js) and
+// triggered by id="logout-link"
 // ---------------------------------------------------------------------------
-document.body.addEventListener("click", function (event) {
-    const link = event.target.closest("#logout-link");
-    if (!link) return;
-    event.preventDefault();
+window.ikoLogout = function () {
     const form = document.createElement("form");
     form.method = "POST";
     form.action = "/logout";
@@ -73,6 +71,13 @@ document.body.addEventListener("click", function (event) {
     }
     document.body.appendChild(form);
     form.submit();
+};
+
+document.body.addEventListener("click", function (event) {
+    const link = event.target.closest("#logout-link");
+    if (!link) return;
+    event.preventDefault();
+    window.ikoLogout();
 });
 
 // ---------------------------------------------------------------------------

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -403,8 +403,10 @@
             class="cds-theme-zone-g10"
             data-carbon-theme="g10"
             prevent-close-on-click-outside="true"
-            th:data-timeout-seconds="${@adminSessionProperties.timeoutSeconds}"
-            th:data-warning-seconds="${@adminSessionProperties.warningBeforeSeconds}"
+            th:with="timeoutSeconds=${@adminSessionProperties.timeoutSeconds},
+                     warningSeconds=${@adminSessionProperties.warningBeforeSeconds}"
+            th:data-timeout-seconds="${timeoutSeconds}"
+            th:data-warning-seconds="${warningSeconds}"
         >
             <cds-modal-header>
                 <cds-modal-heading>


### PR DESCRIPTION
## Header Links

[Artifacts](https://cloud.humanlayer.com/tasks/019ed547-00b0-71ff-9b24-739fe763fa8b/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019ed547-00b0-71ff-9b24-739fe763fa8b) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019ed54d-281d-777f-b79a-5306aa5f4f02)

## What problems was I solving

The admin UI session-timeout feature calls a shared global `window.ikoLogout()` to sign the user out, but that global was never defined. `admin-ui.js` only bound the logout form submission inside the `#logout-link` click handler, so every auto-logout path threw:

```
session-timeout.js:53 Uncaught TypeError: window.ikoLogout is not a function
    at logout (session-timeout.js:53:20)
    at session-timeout.js:64:21
```

As a result, when the inactivity countdown expired (or the timeout modal's "Log out now" button was pressed, or a keep-alive ping failed), the user was **not** logged out. After this PR, the inactivity timeout and the manual logout link both route through the same `/logout` form-submit code path.

## What user-facing changes did I ship

- [src/main/resources/static/js/admin-ui.js](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/185/files#diff-4b809dc943aa4294d0e4c8e539a9361b8e17d5d7282f6c6fcaa4864d5d55e176) - Session-timeout auto-logout now works; expiry/countdown no longer throws a `TypeError`.
- [src/main/resources/templates/layout-internal.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/185/files#diff-59b72572f18390374863b28cd3f6ca4bcf6f2ec7cbd326aa92f9c241b29c4243) - No behavioral change; cleaner Thymeleaf binding of the timeout/warning attributes the timer reads.

## How I implemented it

### Frontend Changes

- [admin-ui.js](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/185/files#diff-4b809dc943aa4294d0e4c8e539a9361b8e17d5d7282f6c6fcaa4864d5d55e176) - Extracted the hidden POST `/logout` form build/submit (including the CSRF token field) out of the `#logout-link` click listener into a top-level `window.ikoLogout = function () { ... }`. The click handler now just `preventDefault()`s and calls [`window.ikoLogout()`](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/185/files#diff-4b809dc943aa4294d0e4c8e539a9361b8e17d5d7282f6c6fcaa4864d5d55e176R80). This is the global `session-timeout.js:53` already expected — no duplicate logout logic.
- [layout-internal.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/185/files#diff-59b72572f18390374863b28cd3f6ca4bcf6f2ec7cbd326aa92f9c241b29c4243) - Hoisted the repeated `@adminSessionProperties.timeoutSeconds` / `warningBeforeSeconds` expressions on the session-timeout modal into a single `th:with` binding, reused by the two `data-*` attributes the timer reads. Cosmetic only.

## Deviations from the plan

No plan file found in the task directory (only `ticket.md`). Nothing to compare against.

## How to verify it

### Worktree setup

```bash
cd /Users/tombokma/IdeaProjects/iko
git fetch origin
git checkout fix/window-ikologout-not-defined
./gradlew bootRun
```

### Manual Testing

- [ ] Open the admin UI and stay idle until the session-timeout modal countdown reaches 0 → user is logged out (redirected to login), and the console shows no `window.ikoLogout is not a function` error.
- [ ] Click "Log out now" in the timeout modal → POSTs to `/logout` and signs out.
- [ ] Click the header logout link (`#logout-link`) → same `/logout` flow as before (regression check).
- [ ] Confirm the `_csrf` token field is still included in the submitted logout form.

### Automated Tests

```bash
./gradlew spotlessCheck
./gradlew test
```

## Description for the changelog

Fix admin UI session-timeout auto-logout by exposing `window.ikoLogout` (resolves `window.ikoLogout is not a function`).
