### PR TITLE
docs: document iko.logging feature flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Integraal Klant & Objectbeeld (IKO)
 
-![Version: 1.4.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)  
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.4.0-informational?style=flat-square)  
 
 IKO is a Kotlin/Spring Boot Application that uses Apache Camel to integrate with external systems via connectors. It ships with an admin UI and a Docker-based local environment.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Integraal Klant & Objectbeeld (IKO)
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)  
+![Version: 1.4.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square)  
 
 IKO is a Kotlin/Spring Boot Application that uses Apache Camel to integrate with external systems via connectors. It ships with an admin UI and a Docker-based local environment.
 
@@ -92,6 +92,16 @@ Notes:
       CAMEL_SSL_TRUSTMANAGERS_KEYSTORE_PASSWORD=changeit
       ```
       Dev keystores and a regeneration script live under [`certs/`](./certs/README.md); replace with real key material in deployed environments and source the passwords from a secret store rather than `.env`.
+    - Logging: request/route logging events can be persisted to the database and pruned on a schedule via the `iko.logging` properties.
+        - `iko.logging.db.enabled` (default `false`): feature flag that toggles persisting logging events to the database. Leave `false` to disable DB logging entirely.
+        - `iko.logging.retention` (default `21d`): how long persisted logging events are kept before the deletion job removes them. Accepts a Spring `Duration` (e.g. `21d`, `48h`).
+        - `iko.logging.deletionCron` (default `0 0 4 * * ?`): Spring cron expression controlling when the deletion job runs (daily at 04:00 by default).
+        - Override locally via `.env` (Spring relaxed binding):
+          ```
+          IKO_LOGGING_DB_ENABLED=false
+          IKO_LOGGING_RETENTION=21d
+          IKO_LOGGING_DELETIONCRON=0 0 4 * * ?
+          ```
 
 ---
 


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/tasks/019ed571-32eb-7f87-a6fa-204eaf8c0c98/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019ed571-32eb-7f87-a6fa-204eaf8c0c98) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019ed574-e9e6-7851-9b6b-64d54cc8eb01)

## What problems was I solving

Database-backed logging — log events persisted, viewable in the admin UI, and pruned on a schedule — already shipped to `rc/1.4.0` (#177), but the three properties that gate and tune it were undocumented. Operators had to read `application.yml` and `LoggingProperties.kt` to discover that DB logging exists, is off by default, and how to change its retention window or deletion schedule.

After this PR, the README's configuration notes document the full `iko.logging` property set, their defaults, value formats, and the matching `.env` override variables — so enabling and tuning DB logging is discoverable without reading source.

## What user-facing changes did I ship

- [README.md](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/186/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) — added a **Logging** subsection to the configuration notes documenting `iko.logging.db.enabled`, `iko.logging.retention`, and `iko.logging.deletionCron` with defaults and `.env` overrides.

## How I implemented it

Docs-only change. No code, defaults, or behavior touched.

### Documentation Changes
- [README.md](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/186/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) — new Logging note slotted into the existing configuration list (after the Camel SSL keystore note). Documents:
  - `iko.logging.db.enabled` (default `false`) — feature flag toggling persistence of logging events to the database.
  - `iko.logging.retention` (default `21d`) — Spring `Duration` retention window before the deletion job prunes events.
  - `iko.logging.deletionCron` (default `0 0 4 * * ?`) — Spring cron controlling when the deletion job runs (daily 04:00).
  - A fenced `.env` block showing the relaxed-binding env vars (`IKO_LOGGING_DB_ENABLED`, `IKO_LOGGING_RETENTION`, `IKO_LOGGING_DELETIONCRON`).

Defaults in the prose were verified against the source of truth before writing:
- `src/main/kotlin/com/ritense/iko/logging/LoggingProperties.kt` — `retention = 21d`, `deletionCron = "0 0 4 * * ?"`, `db.enabled = false`.
- `src/main/resources/application.yml` (`iko.logging.*`) — env-var wiring matches the documented `.env` keys.

## Deviations from the plan

No plan file found in the task directory — this was a direct documentation task driven by the ticket.

## How to verify it

### Manual Testing
- [ ] Open the [README diff](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/186/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5); confirm the Logging note reads clearly and renders correctly on GitHub.
- [ ] Cross-check the documented defaults against `LoggingProperties.kt` and `application.yml`.

### Automated Tests
None — documentation only; no build or test impact.

## Description for the changelog

Document the `iko.logging` feature flags (`db.enabled`, `retention`, `deletionCron`) in the README.
