### PR TITLE
feat: show logging-disabled banner on logging screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ Desktop.ini
 
 # Codelayer
 /thoughts/
+
+# Riptide artifacts (cloud-synced)
+.humanlayer/tasks/

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/LogController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/LogController.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.iko.mvc.controller
 
+import com.ritense.iko.logging.LoggingProperties
 import com.ritense.iko.logging.service.LoggingEventService
 import com.ritense.iko.mvc.controller.ConnectorController.Companion.hxRequest
 import com.ritense.iko.mvc.controller.HomeController.Companion.BASE_FRAGMENT_LOGGING
@@ -36,6 +37,7 @@ import org.springframework.web.servlet.ModelAndView
 @RequestMapping("/admin/logs")
 internal class LogController(
     private val loggingEventService: LoggingEventService,
+    private val loggingProperties: LoggingProperties,
 ) {
     @GetMapping
     fun list(
@@ -48,6 +50,7 @@ internal class LogController(
             addObject("events", page.content)
             addObject("page", page)
             addObject("filter", filter)
+            addObject("loggingDbEnabled", loggingProperties.db.enabled)
         }
     } else {
         val page = loggingEventService.search(filter, pageable)
@@ -55,6 +58,7 @@ internal class LogController(
             addObject("events", page.content)
             addObject("page", page)
             addObject("filter", filter)
+            addObject("loggingDbEnabled", loggingProperties.db.enabled)
             addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
             addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
         }
@@ -87,6 +91,7 @@ internal class LogController(
                     addObject("events", page.content)
                     addObject("page", page)
                     addObject("filter", filter)
+                    addObject("loggingDbEnabled", loggingProperties.db.enabled)
                     addObject("username", SecurityContextHelper.getUserPropertyByKey("name"))
                     addObject("email", SecurityContextHelper.getUserPropertyByKey("email"))
                 },

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -666,6 +666,12 @@ cds-form-item {
 }
 
 /* Logging filter overlay */
+.logging-disabled-notification {
+    display: block;
+    margin-bottom: var(--cds-spacing-05);
+    max-inline-size: 100%;
+}
+
 .app--logging-panel-anchor {
     position: relative;
 }

--- a/src/main/resources/templates/fragments/internal/logging/list.html
+++ b/src/main/resources/templates/fragments/internal/logging/list.html
@@ -20,6 +20,16 @@
     ></div>
     <div th:replace="~{layout-internal :: page-header (title='Logging')}"></div>
 
+    <cds-inline-notification
+        th:if="${loggingDbEnabled == false}"
+        kind="warning"
+        title="Logging disabled"
+        subtitle="No new recordings are captured."
+        hide-close-button
+        low-contrast
+        class="logging-disabled-notification"
+    ></cds-inline-notification>
+
     <div class="app--logging-panel-anchor">
         <!-- Filter overlay form (hidden by default, toggled by funnel button) -->
         <div

--- a/src/test/kotlin/com/ritense/iko/logging/LogControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/ritense/iko/logging/LogControllerIntegrationTest.kt
@@ -184,4 +184,17 @@ internal class LogControllerIntegrationTest : BaseIntegrationTest() {
                     .with(csrf()),
             ).andExpect(status().isOk)
     }
+
+    @Test
+    @WithMockUser(authorities = ["ROLE_ADMIN"])
+    fun `GET logs shows disabled banner when logging db disabled`() {
+        mockMvc
+            .perform(
+                get("/admin/logs")
+                    .header("Hx-Request", "true")
+                    .with(csrf()),
+            ).andExpect(status().isOk)
+            .andExpect(content().string(containsString("Logging disabled")))
+            .andExpect(content().string(containsString("No new recordings are captured.")))
+    }
 }


### PR DESCRIPTION
## Header Links

[Artifacts](https://cloud.humanlayer.com/tasks/019ed580-111e-7bae-9ee1-f171da391ae5/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019ed580-111e-7bae-9ee1-f171da391ae5) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019ed587-567b-7758-aefe-0f0b56eeb9c8)

## What problems was I solving

The admin **Logging** screen lists recorded logging events. When DB logging is turned off via `iko.logging.db.enabled=false`, the table silently stops filling — an admin sees an empty or stale table and has no way to tell whether nothing happened or capture is simply switched off.

After this PR, the Logging screen shows a Carbon inline warning notification above the table whenever DB logging is disabled, clearly stating that no new recordings are captured. Success: an admin viewing the screen with the flag off immediately understands the state.

## What user-facing changes did I ship

- [src/main/resources/templates/fragments/internal/logging/list.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-30183bcb17ae79c3d916eb0ca12db7bc74651375890b57bf8a3f65064d067636) - Warning banner ("Logging disabled / No new recordings are captured.") shown above the table when DB logging is off.
- [src/main/resources/static/css/main.css](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-e643a2d97dadfb5e03c2e1321cc18f8321eef3f5d29a38e154ffe95ec7a55ca9) - Spacing for the banner using a Carbon spacing token.

## How I implemented it

### Backend Changes
- [LogController.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-8cad9a3cb8d1f6eae787b1af99cabbdea32f8e02077b04978b513a4a40bf2c0b) - Inject `LoggingProperties` and add `loggingDbEnabled` (`loggingProperties.db.enabled`) to all three render paths: the HTMX fragment, the full page, and the post-filter render.

### Frontend Changes
- [list.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-30183bcb17ae79c3d916eb0ca12db7bc74651375890b57bf8a3f65064d067636) - `<cds-inline-notification kind="warning" ... hide-close-button low-contrast>` gated on `th:if="${loggingDbEnabled == false}"`, placed directly under the page header. Uses `== false` (not negation) so a null/unset flag does not show the banner.
- [main.css](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-e643a2d97dadfb5e03c2e1321cc18f8321eef3f5d29a38e154ffe95ec7a55ca9) - `.logging-disabled-notification`: `display:block`, `margin-bottom: var(--cds-spacing-05)`, `max-inline-size: 100%`.

### Tests
- [LogControllerIntegrationTest.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-681ac19af576aa64e4668dda41bca3ee560fa1c28026129198b0488e7f922eae) - New test asserts `GET /admin/logs` renders "Logging disabled" and "No new recordings are captured." under the test profile (DB logging disabled).

### Tooling
- [.gitignore](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/187/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) - Ignore `.humanlayer/tasks/` (cloud-synced task artifacts).

## Deviations from the plan

No plan file found in the task directory (only `ticket.md`), so there is nothing to diff against.

## How to verify it

### Worktree setup
```bash
git fetch origin
git checkout feature/toggle-banner-on-logging-screen
```

### Manual Testing
- [ ] Run with `iko.logging.db.enabled=false`, open `/admin/logs` → warning banner appears above the table.
- [ ] Run with `iko.logging.db.enabled=true`, open `/admin/logs` → no banner.
- [ ] Apply a filter on the screen (HTMX path) with the flag off → banner still shown after the partial update.

### Automated Tests
```bash
./gradlew integrationTest --tests "com.ritense.iko.logging.LogControllerIntegrationTest"
```

## Description for the changelog

Show a warning banner on the logging screen when DB logging is disabled.
