### PR TITLE
fix: resolve LazyInitializationException on AggregatedDataProfile detail page

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockwebserver)
+    testImplementation(libs.archunit)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ jacksonModuleKotlin = "2.21.4"
 commonsLang3 = "3.20.0"
 log4j = "2.26.0"
 logbackDb = "1.2.11.1"
-archunit = "1.3.0"
+archunit = "1.4.2"
 
 [libraries]
 # Platforms

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ jacksonModuleKotlin = "2.21.4"
 commonsLang3 = "3.20.0"
 log4j = "2.26.0"
 logbackDb = "1.2.11.1"
+archunit = "1.3.0"
 
 [libraries]
 # Platforms
@@ -93,6 +94,7 @@ assertj-core = { group = "org.assertj", name = "assertj-core" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 spring-security-test = { group = "org.springframework.security", name = "spring-security-test" }
+archunit = { group = "com.tngtech.archunit", name = "archunit", version.ref = "archunit" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/requests/adp.http
+++ b/requests/adp.http
@@ -1,0 +1,27 @@
+#@no-log
+@user=admin
+@password=admin
+
+POST http://keycloak:8082/auth/realms/valtimo/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+username={{user}}&password={{password}}
+    &grant_type=password&client_id=valtimo-console
+
+> {%
+    client.global.set("token",response.body['access_token'])
+%}
+
+###
+
+
+### Search
+GET http://localhost:8080/endpoints/demo/demo-instance/getMockData
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Search
+GET http://localhost:8080/aggregated-data-profiles/TETS
+Authorization: Bearer {{token}}
+Content-Type: application/json
+

--- a/src/main/kotlin/com/ritense/iko/OsivSafeReference.kt
+++ b/src/main/kotlin/com/ritense/iko/OsivSafeReference.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko
+
+/**
+ * Opts a class out of the ArchUnit rule that forbids [org.springframework.data.jpa.repository.JpaRepository.getReferenceById].
+ *
+ * OSIV is disabled (`spring.jpa.open-in-view=false`), so `getReferenceById` returns a lazy proxy that
+ * throws `LazyInitializationException` once a non-id property is touched outside an open Hibernate
+ * session. The default fix is `findById(id).orElseThrow()`, which loads the entity eagerly.
+ *
+ * Annotate a class with this only when `getReferenceById` is used safely — i.e. the proxy is passed
+ * straight to a query (Spring Data derived query, JPQL parameter) where Hibernate reads just the id and
+ * never initializes the proxy. State why in [reason].
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OsivSafeReference(val reason: String)

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.iko.connectors.camel
 
+import com.ritense.iko.OsivSafeReference
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_ENDPOINT_ID_VARIABLE
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_INSTANCE_ID_VARIABLE
 import com.ritense.iko.camel.IkoRouteHelper.Companion.GLOBAL_ERROR_HANDLER_CONFIGURATION
@@ -27,6 +28,7 @@ import org.apache.camel.builder.RouteBuilder
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.UUID
 
+@OsivSafeReference("getReferenceById results are only passed as query parameters; Hibernate reads the id and never initializes the proxy")
 class EndpointAuthRouteBuilder(
     val connectorEndpointRepository: ConnectorEndpointRepository,
     val connectorInstanceRepository: ConnectorInstanceRepository,

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -74,8 +74,8 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
-        val instance = connectorInstanceRepository.getReferenceById(aggregatedDataProfile.connectorInstanceId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
+        val instance = connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(instance.connector)
         val availableSources = sources(aggregatedDataProfile)
         val isCached = cacheService.isCached(aggregatedDataProfile.id.toString())
@@ -307,7 +307,7 @@ internal class AggregatedDataProfileController(
         bindingResult: BindingResult,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.id).orElseThrow()
         val instance = connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElseThrow()
         if (bindingResult.hasErrors()) {
             val modelAndView = ModelAndView("$BASE_FRAGMENT_ADP/edit-panel :: profile-edit").apply {
@@ -338,7 +338,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @RequestParam(required = false) sourceId: String? = null,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val sources = sources(aggregatedDataProfile)
         val connectorInstances = connectorInstanceRepository.findAllByOrderByNameAsc()
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/add").apply {
@@ -356,7 +356,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @PathVariable relationId: UUID,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.find { it.id == relationId }
         val connector = connectorInstanceRepository.findById(relation?.connectorInstanceId!!).orElseThrow()
         val sources = sources(aggregatedDataProfile).apply { this.removeIf { it.id == relationId.toString() } }
@@ -377,7 +377,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @PathVariable relationId: UUID,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/delete").apply {
             addObject(
                 "form",
@@ -394,7 +394,7 @@ internal class AggregatedDataProfileController(
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         aggregatedDataProfileService.removeRoute(aggregatedDataProfile)
         aggregatedDataProfileRepository.delete(aggregatedDataProfile)
 
@@ -414,7 +414,7 @@ internal class AggregatedDataProfileController(
         @Valid @ModelAttribute form: AggregatedDataProfileCacheForm,
         bindingResult: BindingResult,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val isCached = cacheService.isCached(aggregatedDataProfile.id.toString())
         if (bindingResult.hasErrors()) {
             return ModelAndView("$BASE_FRAGMENT_ADP/cache :: cache-panel").apply {
@@ -444,7 +444,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         cacheService.evictByPrefix(aggregatedDataProfile.id.toString())
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
         httpServletResponse.setHeader("HX-Reswap", "innerHTML")
@@ -461,7 +461,7 @@ internal class AggregatedDataProfileController(
         @Valid @ModelAttribute form: RelationCacheForm,
         bindingResult: BindingResult,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.first { it.id == relationId }
         val isCached = cacheService.isCached(relation.id.toString())
         val connectorInstance = connectorInstanceRepository.findById(relation.connectorInstanceId).orElseThrow()
@@ -503,7 +503,7 @@ internal class AggregatedDataProfileController(
         @PathVariable relationId: UUID,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.first { it.id == relationId }
         cacheService.evictByPrefix(relation.id.toString())
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -236,7 +236,7 @@ internal class AggregatedDataProfileController(
     fun endpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_ADP/add :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)
@@ -247,7 +247,7 @@ internal class AggregatedDataProfileController(
     fun relationAddEndpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_RELATION/add :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)
@@ -258,7 +258,7 @@ internal class AggregatedDataProfileController(
     fun relationEditEndpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_RELATION/edit :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
@@ -57,7 +57,7 @@ internal class RelationController(
         bindingResult: org.springframework.validation.BindingResult,
         httpServletResponse: HttpServletResponse,
     ): List<ModelAndView> {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val sources = sources(aggregatedDataProfile)
         val connectorInstance =
             connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElse(null)
@@ -106,7 +106,7 @@ internal class RelationController(
         bindingResult: org.springframework.validation.BindingResult,
         httpServletResponse: HttpServletResponse,
     ): List<ModelAndView> {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val sources = sources(aggregatedDataProfile).apply { this.removeIf { it.id == form.id.toString() } }
         val connectorInstance = connectorInstanceRepository.findById(form.connectorInstanceId).orElse(null)
         val connectorEndpoints =
@@ -149,7 +149,7 @@ internal class RelationController(
         @Valid @ModelAttribute form: DeleteRelationForm,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         aggregatedDataProfile.removeRelation(form)
         aggregatedDataProfileRepository.save(aggregatedDataProfile)
         if (aggregatedDataProfile.isActive) {

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
@@ -30,7 +30,7 @@ class UniqueRelationValidator(
         context: ConstraintValidatorContext,
     ): Boolean {
         if (form.propertyName.isBlank()) return false
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val existing = aggregatedDataProfile.relations.find { it.id == form.id }
         val duplicateOnSameLevel = aggregatedDataProfile.relations
             .any { it.propertyName == form.propertyName && it.sourceId == form.sourceId }

--- a/src/test/kotlin/com/ritense/iko/architecture/OsivLazyReferenceArchTest.kt
+++ b/src/test/kotlin/com/ritense/iko/architecture/OsivLazyReferenceArchTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.architecture
+
+import com.ritense.iko.OsivSafeReference
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import org.junit.jupiter.api.Test
+
+class OsivLazyReferenceArchTest {
+    private val productionClasses =
+        ClassFileImporter()
+            .withImportOption(ImportOption.DoNotIncludeTests())
+            .importPackages("com.ritense.iko")
+
+    @Test
+    fun `production code does not call getReferenceById because OSIV is disabled`() {
+        classes()
+            .should(notCallGetReferenceById)
+            .because(
+                "spring.jpa.open-in-view=false: JpaRepository.getReferenceById returns a lazy proxy that throws " +
+                    "LazyInitializationException when a property is accessed outside an open session. " +
+                    "Use findById(id).orElseThrow(). If the reference is only passed to a query (id-only access), " +
+                    "annotate the declaring class with @OsivSafeReference.",
+            )
+            .check(productionClasses)
+    }
+
+    private val notCallGetReferenceById =
+        object : ArchCondition<JavaClass>("not call JpaRepository.getReferenceById") {
+            override fun check(item: JavaClass, events: ConditionEvents) {
+                if (item.isOrEnclosedByOsivSafe()) return
+                item.methodCallsFromSelf
+                    .filter { it.target.name == "getReferenceById" }
+                    .forEach { call -> events.add(SimpleConditionEvent.violated(call, call.description)) }
+            }
+        }
+
+    private fun JavaClass.isOrEnclosedByOsivSafe(): Boolean {
+        var current: JavaClass? = this
+        while (current != null) {
+            if (current.isAnnotatedWith(OsivSafeReference::class.java)) return true
+            current = current.enclosingClass.orElse(null)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
## Header Links

[PR #190](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190) | [Artifacts](https://cloud.humanlayer.com/tasks/019ef57c-96a8-713a-84c3-88242094f19f/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019ef57c-96a8-713a-84c3-88242094f19f)

## What problems was I solving

Editing an `AggregatedDataProfile` broke the detail page with:

```
org.hibernate.LazyInitializationException: Could not initialize proxy
[com.ritense.iko.aggregateddataprofile.domain.AggregatedDataProfile#...] - no session
```

The MVC controllers and the relation validator loaded entities with JPA's `getReferenceById`, which returns an **uninitialized lazy proxy**. As soon as the rendering layer (or validation) touched a non-id field — e.g. `aggregatedDataProfile.relations`, `aggregatedDataProfile.connectorInstanceId` — outside an active Hibernate session, Hibernate threw `LazyInitializationException`. Result: the detail/edit page and several related fragments (relation add/edit/delete, cache toggles, endpoint dropdowns, unique-relation validation) were unusable.

After this hotfix the detail page renders, relations and endpoint dropdowns load, cache toggles work, and the unique-relation validator runs — without lazy-proxy session errors. Missing ids now fail fast with a clear `NoSuchElementException` instead of a confusing proxy error.

## What user-facing changes did I ship

- [AggregatedDataProfileController.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-46b6ca212b87080314554448582e63b5fd63631192ab978b652ff3fb081c7848) — detail page, relation add/edit/delete fragments, cache toggle/evict fragments, and endpoint dropdowns now load the fully-initialized entity instead of a lazy proxy.
- [RelationController.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-cf54e1b5528dd00181eb0dd17cc79eab63462274dca2a8e118635f4f01a4277c) — relation create/edit/delete handlers load the profile eagerly.
- [UniqueRelationValidator.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-9fc8274a7a35a924eba137af3371376b66e391465db6358067dd326f723a9180) — unique-relation validation no longer dereferences a detached proxy.

## How I implemented it

Root cause: `JpaRepository.getReferenceById(id)` is lazy — it returns a proxy and defers the DB hit until a non-id property is accessed. In a request-rendering / bean-validation context there is no open session at access time, so any deref throws `LazyInitializationException`.

Fix: replace every `getReferenceById(id)` with `findById(id).orElseThrow()`, which eagerly loads the entity within the repository call (session open) and returns a real, initialized instance. Missing rows now surface as `NoSuchElementException` rather than a deferred proxy failure.

### Backend Changes

- **AggregatedDataProfileController.kt** — 13 call sites converted across `detail`, `endpoints`, `relationAddEndpoints`, `relationEditEndpoints`, the edit/save handler, relation add/edit/delete fragments, and the cache enable/evict handlers (both profile- and relation-level).
- **RelationController.kt** — 3 call sites in the relation create, edit, and delete handlers.
- **UniqueRelationValidator.kt** — 1 call site in `isValid`, so validation reads `relations` from a live entity.

Note: several call sites in these files already used `findById(...).orElseThrow()` / `.orElse(null)` — this change makes the entity loading consistent across the controllers.

### Guardrail (ArchUnit)

To stop this regression from recurring, an ArchUnit rule fails the build if any production class calls `getReferenceById`:

- [OsivLazyReferenceArchTest.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-23631fefbeb0fab1fefdbf9946ff8872c5cc88842ca5af09af57dc85b3fc3eaa) — runs under `./gradlew test` (so it is part of `check` and the CI build). Imports production classes only (`DoNotIncludeTests`) and flags every `getReferenceById` call. Detection works inside Kotlin lambda bodies (verified by removing the escape-hatch annotation and watching it fail).
- [OsivSafeReference.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-7f17f15416b774e2883271978436f300fd84e056167b3f741c77608a4244cae4) — `@OsivSafeReference(reason)` class annotation: the documented escape hatch for intentional id-only use (passing the proxy straight to a query, where Hibernate reads only the id and never initializes it). The rule skips a class if it or any enclosing class carries the annotation.
- [EndpointAuthRouteBuilder.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-a070aea2965a68762ac5840a663e01d0046bfc80ec93c24c68803fae9d660eeb) — annotated `@OsivSafeReference`; its two `getReferenceById` calls pass the proxy as a query parameter only, so they are safe and intentionally exempt.
- [libs.versions.toml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87df) / [build.gradle.kts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-c0dfa6bc7a8685217f70a860145fbdf416d449eaff052fa28352c5cec1a98c06) — add the `archunit` `1.4.2` test dependency.

## Deviations from the plan

No plan file found in the task directory (only `ticket.md`). Hotfix per ticket: branch `rc/1.4.1` off `main`.

## How to verify it

### Manual Testing
- [ ] Open an existing `AggregatedDataProfile` detail page → renders without `LazyInitializationException`.
- [ ] Edit the profile and save → succeeds.
- [ ] Add / edit / delete a relation → fragments render and persist.
- [ ] Toggle and evict cache at both profile and relation level.
- [ ] Endpoint dropdowns populate when selecting a connector instance.
- [ ] Submit a duplicate relation → unique-relation validator rejects it.

For ad-hoc API checks, [requests/adp.http](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/190/files#diff-6fe16be1692d81789773c73976222108cddfb9359e1ff1883a321c6030b083f3) provides a Keycloak token request plus sample endpoint / aggregated-data-profile calls.

### Automated Tests
```bash
./gradlew test
```
The new `OsivLazyReferenceArchTest` fails the build if `getReferenceById` is reintroduced without an `@OsivSafeReference` justification.

## Description for the changelog

Fix `LazyInitializationException` on the AggregatedDataProfile detail page and related fragments by loading entities eagerly with `findById().orElseThrow()` instead of `getReferenceById()`, and add an ArchUnit rule that forbids `getReferenceById` (OSIV is disabled) going forward.
