### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -145,6 +145,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(libs.mockito.kotlin)
     testImplementation(libs.mockwebserver)
+    testImplementation(libs.archunit)
     testRuntimeOnly(libs.junit.platform.launcher)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
-version=1.4.0
+version=1.4.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ jacksonModuleKotlin = "2.21.4"
 commonsLang3 = "3.20.0"
 log4j = "2.26.0"
 logbackDb = "1.2.11.1"
-archunit = "1.3.0"
+archunit = "1.4.2"
 
 [libraries]
 # Platforms

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ jacksonModuleKotlin = "2.21.4"
 commonsLang3 = "3.20.0"
 log4j = "2.26.0"
 logbackDb = "1.2.11.1"
+archunit = "1.3.0"
 
 [libraries]
 # Platforms
@@ -93,6 +94,7 @@ assertj-core = { group = "org.assertj", name = "assertj-core" }
 mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "mockwebserver" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 spring-security-test = { group = "org.springframework.security", name = "spring-security-test" }
+archunit = { group = "com.tngtech.archunit", name = "archunit", version.ref = "archunit" }
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/requests/adp.http
+++ b/requests/adp.http
@@ -1,0 +1,27 @@
+#@no-log
+@user=admin
+@password=admin
+
+POST http://keycloak:8082/auth/realms/valtimo/protocol/openid-connect/token
+Content-Type: application/x-www-form-urlencoded
+
+username={{user}}&password={{password}}
+    &grant_type=password&client_id=valtimo-console
+
+> {%
+    client.global.set("token",response.body['access_token'])
+%}
+
+###
+
+
+### Search
+GET http://localhost:8080/endpoints/demo/demo-instance/getMockData
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Search
+GET http://localhost:8080/aggregated-data-profiles/TETS
+Authorization: Bearer {{token}}
+Content-Type: application/json
+

--- a/src/main/kotlin/com/ritense/iko/OsivSafeReference.kt
+++ b/src/main/kotlin/com/ritense/iko/OsivSafeReference.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko
+
+/**
+ * Opts a class out of the ArchUnit rule that forbids [org.springframework.data.jpa.repository.JpaRepository.getReferenceById].
+ *
+ * OSIV is disabled (`spring.jpa.open-in-view=false`), so `getReferenceById` returns a lazy proxy that
+ * throws `LazyInitializationException` once a non-id property is touched outside an open Hibernate
+ * session. The default fix is `findById(id).orElseThrow()`, which loads the entity eagerly.
+ *
+ * Annotate a class with this only when `getReferenceById` is used safely — i.e. the proxy is passed
+ * straight to a query (Spring Data derived query, JPQL parameter) where Hibernate reads just the id and
+ * never initializes the proxy. State why in [reason].
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class OsivSafeReference(val reason: String)

--- a/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/EndpointAuthRouteBuilder.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.iko.connectors.camel
 
+import com.ritense.iko.OsivSafeReference
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_ENDPOINT_ID_VARIABLE
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_INSTANCE_ID_VARIABLE
 import com.ritense.iko.camel.IkoRouteHelper.Companion.GLOBAL_ERROR_HANDLER_CONFIGURATION
@@ -27,6 +28,7 @@ import org.apache.camel.builder.RouteBuilder
 import org.springframework.security.core.context.SecurityContextHolder
 import java.util.UUID
 
+@OsivSafeReference("getReferenceById results are only passed as query parameters; Hibernate reads the id and never initializes the proxy")
 class EndpointAuthRouteBuilder(
     val connectorEndpointRepository: ConnectorEndpointRepository,
     val connectorInstanceRepository: ConnectorInstanceRepository,

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -74,8 +74,8 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
-        val instance = connectorInstanceRepository.getReferenceById(aggregatedDataProfile.connectorInstanceId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
+        val instance = connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(instance.connector)
         val availableSources = sources(aggregatedDataProfile)
         val isCached = cacheService.isCached(aggregatedDataProfile.id.toString())
@@ -307,7 +307,7 @@ internal class AggregatedDataProfileController(
         bindingResult: BindingResult,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.id).orElseThrow()
         val instance = connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElseThrow()
         if (bindingResult.hasErrors()) {
             val modelAndView = ModelAndView("$BASE_FRAGMENT_ADP/edit-panel :: profile-edit").apply {
@@ -338,7 +338,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @RequestParam(required = false) sourceId: String? = null,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val sources = sources(aggregatedDataProfile)
         val connectorInstances = connectorInstanceRepository.findAllByOrderByNameAsc()
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/add").apply {
@@ -356,7 +356,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @PathVariable relationId: UUID,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.find { it.id == relationId }
         val connector = connectorInstanceRepository.findById(relation?.connectorInstanceId!!).orElseThrow()
         val sources = sources(aggregatedDataProfile).apply { this.removeIf { it.id == relationId.toString() } }
@@ -377,7 +377,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         @PathVariable relationId: UUID,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val modelAndView = ModelAndView("$BASE_FRAGMENT_RELATION/delete").apply {
             addObject(
                 "form",
@@ -394,7 +394,7 @@ internal class AggregatedDataProfileController(
         @RequestHeader(HX_REQUEST_HEADER) isHxRequest: Boolean = false,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         aggregatedDataProfileService.removeRoute(aggregatedDataProfile)
         aggregatedDataProfileRepository.delete(aggregatedDataProfile)
 
@@ -414,7 +414,7 @@ internal class AggregatedDataProfileController(
         @Valid @ModelAttribute form: AggregatedDataProfileCacheForm,
         bindingResult: BindingResult,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val isCached = cacheService.isCached(aggregatedDataProfile.id.toString())
         if (bindingResult.hasErrors()) {
             return ModelAndView("$BASE_FRAGMENT_ADP/cache :: cache-panel").apply {
@@ -444,7 +444,7 @@ internal class AggregatedDataProfileController(
         @PathVariable id: UUID,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         cacheService.evictByPrefix(aggregatedDataProfile.id.toString())
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")
         httpServletResponse.setHeader("HX-Reswap", "innerHTML")
@@ -461,7 +461,7 @@ internal class AggregatedDataProfileController(
         @Valid @ModelAttribute form: RelationCacheForm,
         bindingResult: BindingResult,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.first { it.id == relationId }
         val isCached = cacheService.isCached(relation.id.toString())
         val connectorInstance = connectorInstanceRepository.findById(relation.connectorInstanceId).orElseThrow()
@@ -503,7 +503,7 @@ internal class AggregatedDataProfileController(
         @PathVariable relationId: UUID,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(id)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(id).orElseThrow()
         val relation = aggregatedDataProfile.relations.first { it.id == relationId }
         cacheService.evictByPrefix(relation.id.toString())
         httpServletResponse.setHeader("HX-Retarget", "#view-panel")

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/AggregatedDataProfileController.kt
@@ -236,7 +236,7 @@ internal class AggregatedDataProfileController(
     fun endpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_ADP/add :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)
@@ -247,7 +247,7 @@ internal class AggregatedDataProfileController(
     fun relationAddEndpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_RELATION/add :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)
@@ -258,7 +258,7 @@ internal class AggregatedDataProfileController(
     fun relationEditEndpoints(
         @RequestParam connectorInstanceId: UUID,
     ): ModelAndView {
-        val connector = connectorInstanceRepository.getReferenceById(connectorInstanceId)
+        val connector = connectorInstanceRepository.findById(connectorInstanceId).orElseThrow()
         val endpoints = connectorEndpointRepository.findByConnector(connector.connector)
         return ModelAndView("$BASE_FRAGMENT_RELATION/edit :: connectorEndpoints").apply {
             addObject("connectorEndpoints", endpoints)

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/RelationController.kt
@@ -57,7 +57,7 @@ internal class RelationController(
         bindingResult: org.springframework.validation.BindingResult,
         httpServletResponse: HttpServletResponse,
     ): List<ModelAndView> {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val sources = sources(aggregatedDataProfile)
         val connectorInstance =
             connectorInstanceRepository.findById(aggregatedDataProfile.connectorInstanceId).orElse(null)
@@ -106,7 +106,7 @@ internal class RelationController(
         bindingResult: org.springframework.validation.BindingResult,
         httpServletResponse: HttpServletResponse,
     ): List<ModelAndView> {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val sources = sources(aggregatedDataProfile).apply { this.removeIf { it.id == form.id.toString() } }
         val connectorInstance = connectorInstanceRepository.findById(form.connectorInstanceId).orElse(null)
         val connectorEndpoints =
@@ -149,7 +149,7 @@ internal class RelationController(
         @Valid @ModelAttribute form: DeleteRelationForm,
         httpServletResponse: HttpServletResponse,
     ): ModelAndView {
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         aggregatedDataProfile.removeRelation(form)
         aggregatedDataProfileRepository.save(aggregatedDataProfile)
         if (aggregatedDataProfile.isActive) {

--- a/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/model/validation/UniqueRelationValidator.kt
@@ -30,7 +30,7 @@ class UniqueRelationValidator(
         context: ConstraintValidatorContext,
     ): Boolean {
         if (form.propertyName.isBlank()) return false
-        val aggregatedDataProfile = aggregatedDataProfileRepository.getReferenceById(form.aggregatedDataProfileId)
+        val aggregatedDataProfile = aggregatedDataProfileRepository.findById(form.aggregatedDataProfileId).orElseThrow()
         val existing = aggregatedDataProfile.relations.find { it.id == form.id }
         val duplicateOnSameLevel = aggregatedDataProfile.relations
             .any { it.propertyName == form.propertyName && it.sourceId == form.sourceId }

--- a/src/test/kotlin/com/ritense/iko/architecture/OsivLazyReferenceArchTest.kt
+++ b/src/test/kotlin/com/ritense/iko/architecture/OsivLazyReferenceArchTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.architecture
+
+import com.ritense.iko.OsivSafeReference
+import com.tngtech.archunit.core.domain.JavaClass
+import com.tngtech.archunit.core.importer.ClassFileImporter
+import com.tngtech.archunit.core.importer.ImportOption
+import com.tngtech.archunit.lang.ArchCondition
+import com.tngtech.archunit.lang.ConditionEvents
+import com.tngtech.archunit.lang.SimpleConditionEvent
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes
+import org.junit.jupiter.api.Test
+
+class OsivLazyReferenceArchTest {
+    private val productionClasses =
+        ClassFileImporter()
+            .withImportOption(ImportOption.DoNotIncludeTests())
+            .importPackages("com.ritense.iko")
+
+    @Test
+    fun `production code does not call getReferenceById because OSIV is disabled`() {
+        classes()
+            .should(notCallGetReferenceById)
+            .because(
+                "spring.jpa.open-in-view=false: JpaRepository.getReferenceById returns a lazy proxy that throws " +
+                    "LazyInitializationException when a property is accessed outside an open session. " +
+                    "Use findById(id).orElseThrow(). If the reference is only passed to a query (id-only access), " +
+                    "annotate the declaring class with @OsivSafeReference.",
+            )
+            .check(productionClasses)
+    }
+
+    private val notCallGetReferenceById =
+        object : ArchCondition<JavaClass>("not call JpaRepository.getReferenceById") {
+            override fun check(item: JavaClass, events: ConditionEvents) {
+                if (item.isOrEnclosedByOsivSafe()) return
+                item.methodCallsFromSelf
+                    .filter { it.target.name == "getReferenceById" }
+                    .forEach { call -> events.add(SimpleConditionEvent.violated(call, call.description)) }
+            }
+        }
+
+    private fun JavaClass.isOrEnclosedByOsivSafe(): Boolean {
+        var current: JavaClass? = this
+        while (current != null) {
+            if (current.isAnnotatedWith(OsivSafeReference::class.java)) return true
+            current = current.enclosingClass.orElse(null)
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Bumps the project version from 1.4.0 to 1.4.1 in `gradle.properties` for the rc/1.4.1 hotfix release.

Follow-up to #190 (LazyInitializationException fix + ArchUnit guardrail), which merged the code changes but left the version at 1.4.0.