### PR TITLE
chore: bump version to 1.4.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
-version=1.4.0
+version=1.4.1


### PR DESCRIPTION
Bumps the project version in `gradle.properties` from `1.4.0` to `1.4.1`.

Follow-up to #190 (LazyInitializationException hotfix + ArchUnit guardrail), which merged the code but left the version unchanged. Branched off `main` so the diff is the single version line only.