### PR TITLE
test(e2e): Playwright end-to-end test suite + CI workflow (#251)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,65 @@
+name: End-to-end (Playwright)
+
+# Boots the full e2e stack (built app image + Postgres + Redis + live Keycloak)
+# via docker-compose-e2e.yaml, gates on the actuator readiness probe, runs the
+# Playwright suite against the running app, tears the stack down and archives the
+# Playwright HTML report as a build artifact.
+#
+# Triggered only on release-candidate branches (rc/X.Y.Z), matching the repo's
+# rc/* branch convention (see restrict-main-pr.yml).
+
+on:
+    push:
+        branches:
+            - 'rc/[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+    contents: read
+
+concurrency:
+    group: e2e-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    e2e:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v6
+
+            -   name: Setup Node
+                uses: actions/setup-node@v4
+                with:
+                    node-version: 20
+                    cache: npm
+                    cache-dependency-path: e2e/package-lock.json
+
+            -   name: Bring up e2e stack
+                run: docker compose -f docker-compose-e2e.yaml up -d --build
+
+            -   name: Wait for app readiness
+                run: ./scripts/wait-for-health.sh http://localhost:9090/actuator/health/readiness
+
+            -   name: Install e2e dependencies
+                working-directory: e2e
+                run: npm ci
+
+            -   name: Install Playwright browsers
+                working-directory: e2e
+                run: npx playwright install --with-deps
+
+            -   name: Run Playwright suite
+                working-directory: e2e
+                run: npx playwright test
+
+            -   name: Tear down e2e stack
+                if: always()
+                run: docker compose -f docker-compose-e2e.yaml down -v
+
+            -   name: Upload Playwright report
+                if: always()
+                uses: actions/upload-artifact@v6
+                with:
+                    name: playwright-report
+                    path: e2e/playwright-report
+                    retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,7 +30,7 @@ jobs:
             -   name: Setup Node
                 uses: actions/setup-node@v4
                 with:
-                    node-version: 20
+                    node-version: 24
                     cache: npm
                     cache-dependency-path: e2e/package-lock.json
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,42 @@ Notes:
 
 ---
 
+### End-to-end tests (Playwright)
+
+A Playwright end-to-end suite lives under [`e2e/`](./e2e). It drives a **fully running stack** through a real browser (Admin UI OAuth2/OIDC login, Connectors and Aggregated Data Profiles screens) and over raw HTTP (the public REST API, including the Camel per-endpoint / per-profile role checks).
+
+The suite does **not** start the app itself — it always targets an already-running stack. `docker-compose-e2e.yaml` brings up the built app image plus Postgres, Redis, a live Keycloak (`valtimo` realm) and a BRP personen mock, and mounts the deterministic Flyway seed in `e2e/seed/` (kept out of `src/` so it can never reach a real database).
+
+Run it locally:
+```bash
+# 1. Bring up the full e2e stack (app + Postgres + Redis + Keycloak + BRP mock)
+docker compose -f docker-compose-e2e.yaml up -d --build
+
+# 2. Wait until the app reports readiness (actuator published on 9090)
+./scripts/wait-for-health.sh http://localhost:9090/actuator/health/readiness
+
+# 3. Install dependencies + browsers and run the suite
+cd e2e
+npm ci
+npx playwright install --with-deps
+npx playwright test
+
+# 4. Inspect the HTML report
+npx playwright show-report
+
+# 5. Tear the stack down (removes volumes)
+cd ..
+docker compose -f docker-compose-e2e.yaml down -v
+```
+
+Useful extras:
+- `npm run typecheck` (in `e2e/`) type-checks the suite without running it (`tsc --noEmit`).
+- Configuration (base URLs, Keycloak realm/client, seeded users) lives in `e2e/fixtures/env.ts` and is overridable via `E2E_*` environment variables; the defaults match `docker-compose-e2e.yaml`.
+
+> CI runs this suite automatically on release-candidate branches — see [End-to-end (Playwright)](#end-to-end-playwright-githubworkflowse2eyml) below.
+
+---
+
 ### Admin UI
 - URL: `http://localhost:8080/admin`
 - Tutorial (Aggregated Data Profile):
@@ -145,6 +181,13 @@ Notes:
     - `snapshot-YYYYMMDDHHmm`
     - `branch-<name>` for non-main branches
 - Adds OCI labels/annotations (title, description, revision, source, created).
+
+#### End-to-end (Playwright) (`.github/workflows/e2e.yml`)
+- Triggered on `push` to release-candidate branches only (`rc/X.Y.Z`, e.g. `rc/1.5.0`), matching the repo's `rc/*` branch convention.
+- Boots the full e2e stack via `docker-compose-e2e.yaml` (built app image + Postgres + Redis + live Keycloak + BRP mock).
+- Gates on the actuator readiness probe (`scripts/wait-for-health.sh`) before running the Playwright suite against the running app.
+- Tears the stack down (`down -v`) and archives the Playwright HTML report as a build artifact (7-day retention), even on failure.
+- It does **not** run on `pull_request` or on `main`; to exercise it, push (or open) a `rc/X.Y.Z` branch.
 
 #### Manual release workflow (`.github/workflows/start-manual-release.yml`)
 This workflow is used to cut a formal release that publishes a versioned container image and a GitHub Release.

--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -12,7 +12,9 @@ name: iko-e2e
 # Actuator is published on 9090 for the readiness gate (scripts/wait-for-health.sh).
 #
 # Phase 3 adds the mounted Flyway seed (/seed) + SPRING_FLYWAY_LOCATIONS.
-# Phase 5 adds the BRP personen mock and the resource-server JWT role env.
+# Phase 5 adds the BRP personen mock, the bundled OpenAPI spec mount
+# (/openapi-specs) and the resource-server JWT role env so `admin`'s realm roles
+# become authorities and satisfy the Camel per-profile / per-endpoint checks.
 #
 # The baseline seed lives in e2e/seed/V9999.01.01.1__e2e_baseline.sql and is
 # mounted read-only into the app container at /seed. SPRING_FLYWAY_LOCATIONS adds
@@ -47,20 +49,49 @@ services:
             SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI: http://keycloak:8082/auth/realms/valtimo
             # Resource server — JWT issuer for the public REST API
             SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://keycloak:8082/auth/realms/valtimo
+            # The repo realm does not populate resource_access.iko.roles (the
+            # production default authorities-claim-name), so map the realm roles to
+            # authorities instead. The `iko` client's "realm roles" protocol mapper
+            # in imports/keycloak/realm.json emits them as a top-level multivalued
+            # `roles` claim (claim.name=roles), and its audience mapper sets aud=iko.
+            # So the authorities claim is `roles` and the audience stays `iko`
+            # (the production default), making `admin`'s ROLE_ADMIN an authority that
+            # satisfies the Camel per-profile / per-endpoint checks.
+            #
+            # NOTE: the structure outline proposed [realm_access][roles] + audience
+            # `account`; that does not match this realm's `iko` client mappers (the
+            # access token has no realm_access claim and aud=iko), so the value below
+            # reflects the tokens the realm actually issues. Audience stays `iko`
+            # (the application.yml default), so it is not overridden here.
+            #
+            # The underscores at the hyphen positions are deliberate:
+            # authorities-claim-name is read via @Value (SecurityConfig), and Spring's
+            # relaxed env binding maps SPRING_..._AUTHORITIES_CLAIM_NAME ->
+            # spring.security.oauth2.resourceserver.jwt.authorities-claim-name.
+            SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_AUTHORITIES_CLAIM_NAME: "[roles]"
             # Cookies over plain HTTP for the local/CI e2e run
             SERVER_SERVLET_SESSION_COOKIE_SECURE: "false"
             # Run the bundled classpath migrations plus the mounted /seed baseline
             # (e2e/seed). The seed adds namespaced `e2e-conn-*` connectors so the
             # Connectors list spans multiple pages independent of test order.
             SPRING_FLYWAY_LOCATIONS: classpath:db/migration,filesystem:/seed
+            # The seed's BRP connector code embeds Camel ${variable...} expressions;
+            # disable Flyway placeholder replacement so they are stored verbatim
+            # (mirrors application-test.yml). Production migrations use no ${} placeholders.
+            SPRING_FLYWAY_PLACEHOLDER_REPLACEMENT: "false"
         volumes:
             - ./e2e/seed:/seed:ro
+            # Bundled OpenAPI documents the seeded connectors reference via
+            # apiSpecificationUrl=file:/openapi-specs/<file>.yaml (BRP personen).
+            - ./openapi-specs:/openapi-specs:ro
         depends_on:
             postgres:
                 condition: service_started
             redis:
                 condition: service_healthy
             keycloak:
+                condition: service_started
+            haalcentraal-personen:
                 condition: service_started
 
     postgres:
@@ -100,3 +131,15 @@ services:
         volumes:
             - ./imports/keycloak:/opt/keycloak/data/import
         command: "start-dev --import-realm --http-port=8082 --hostname keycloak --http-enabled=true"
+
+    # BRP personen mock — the one external system the in-scope API specs hit.
+    # Plain HTTP (no mTLS sidecar): the seeded `e2e-brp` connector calls it
+    # in-network at http://haalcentraal-personen:5010 via rest-openapi.
+    haalcentraal-personen:
+        container_name: iko-e2e-haalcentraal-personen
+        image: ghcr.io/brp-api/personen-mock:2.7.0-latest
+        environment:
+            - ASPNETCORE_ENVIRONMENT=Release
+            - ASPNETCORE_URLS=http://+:5010
+        ports:
+            - "5010:5010"

--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -13,6 +13,12 @@ name: iko-e2e
 #
 # Phase 3 adds the mounted Flyway seed (/seed) + SPRING_FLYWAY_LOCATIONS.
 # Phase 5 adds the BRP personen mock and the resource-server JWT role env.
+#
+# The baseline seed lives in e2e/seed/V9999.01.01.1__e2e_baseline.sql and is
+# mounted read-only into the app container at /seed. SPRING_FLYWAY_LOCATIONS adds
+# that filesystem location alongside the bundled classpath migrations so Flyway
+# applies the V9999 baseline on boot. The seed is intentionally not checked into
+# src/, so it can never run against a production database.
 
 services:
 
@@ -43,6 +49,12 @@ services:
             SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://keycloak:8082/auth/realms/valtimo
             # Cookies over plain HTTP for the local/CI e2e run
             SERVER_SERVLET_SESSION_COOKIE_SECURE: "false"
+            # Run the bundled classpath migrations plus the mounted /seed baseline
+            # (e2e/seed). The seed adds namespaced `e2e-conn-*` connectors so the
+            # Connectors list spans multiple pages independent of test order.
+            SPRING_FLYWAY_LOCATIONS: classpath:db/migration,filesystem:/seed
+        volumes:
+            - ./e2e/seed:/seed:ro
         depends_on:
             postgres:
                 condition: service_started

--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -1,0 +1,90 @@
+name: iko-e2e
+
+# End-to-end stack for the Playwright suite (e2e/).
+#
+# Brings up the built app image (same Dockerfile as snapshot-releases.yml) plus
+# Postgres, Redis and a live Keycloak importing the `valtimo` realm. Keycloak runs
+# with `--hostname keycloak` so its issuer URI resolves inside the compose network
+# (no /etc/hosts hack). The app's OAuth2 issuer URIs point at the in-network
+# `http://keycloak:8082/auth/realms/valtimo`, while the browser/token clients on the
+# host reach Keycloak via the published 8082 port (same host:port, so issuer matches).
+#
+# Actuator is published on 9090 for the readiness gate (scripts/wait-for-health.sh).
+#
+# Phase 3 adds the mounted Flyway seed (/seed) + SPRING_FLYWAY_LOCATIONS.
+# Phase 5 adds the BRP personen mock and the resource-server JWT role env.
+
+services:
+
+    iko-app:
+        container_name: iko-e2e-app
+        build:
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - "8080:8080"
+            - "9090:9090"
+        environment:
+            # Fixed Base64 AES-256 key — must match the key used to encrypt any
+            # seeded connector_instance_config ciphertext (Phase 5).
+            IKO_CRYPTO_KEY: AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=
+            # Datasource
+            SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/iko-db
+            SPRING_DATASOURCE_USERNAME: iko-admin
+            SPRING_DATASOURCE_PASSWORD: secret
+            # Redis
+            SPRING_DATA_REDIS_HOST: redis
+            SPRING_DATA_REDIS_PORT: "6379"
+            # OAuth2 / OIDC — admin UI login (authorization code) against live Keycloak
+            SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_ID: iko
+            SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KEYCLOAK_CLIENT_SECRET: ThisIsNotASecret
+            SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KEYCLOAK_ISSUER_URI: http://keycloak:8082/auth/realms/valtimo
+            # Resource server — JWT issuer for the public REST API
+            SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUER_URI: http://keycloak:8082/auth/realms/valtimo
+            # Cookies over plain HTTP for the local/CI e2e run
+            SERVER_SERVLET_SESSION_COOKIE_SECURE: "false"
+        depends_on:
+            postgres:
+                condition: service_started
+            redis:
+                condition: service_healthy
+            keycloak:
+                condition: service_started
+
+    postgres:
+        container_name: iko-e2e-postgres
+        image: 'postgres:latest'
+        environment:
+            - POSTGRES_DB=iko-db
+            - POSTGRES_PASSWORD=secret
+            - POSTGRES_USER=iko-admin
+        ports:
+            - "5432:5432"
+
+    redis:
+        container_name: iko-e2e-redis
+        image: redis:8.4.0-alpine
+        ports:
+            - "6379:6379"
+        healthcheck:
+            test: [ "CMD", "redis-cli", "ping" ]
+            interval: 10s
+            timeout: 5s
+            retries: 3
+            start_period: 5s
+
+    keycloak:
+        container_name: iko-e2e-keycloak
+        image: quay.io/keycloak/keycloak:24.0.1
+        ports:
+            - "8082:8082"
+        environment:
+            KEYCLOAK_ADMIN: admin
+            KEYCLOAK_ADMIN_PASSWORD: admin
+            KC_HTTP_RELATIVE_PATH: /auth
+            PROXY_ADDRESS_FORWARDING: "true"
+            KC_HTTP_ENABLED: "true"
+            KC_HTTPS_ENABLED: "false"
+        volumes:
+            - ./imports/keycloak:/opt/keycloak/data/import
+        command: "start-dev --import-realm --http-port=8082 --hostname keycloak --http-enabled=true"

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+playwright-report/
+test-results/
+.auth/

--- a/e2e/fixtures/api-token.ts
+++ b/e2e/fixtures/api-token.ts
@@ -1,0 +1,107 @@
+import {
+    test as base,
+    request as playwrightRequest,
+    type APIRequestContext,
+} from "@playwright/test";
+import {
+    ADMIN_USER,
+    APP_BASE_URL,
+    KEYCLOAK_TOKEN_URL,
+    OIDC_CLIENT_ID,
+    OIDC_CLIENT_SECRET,
+} from "./env";
+
+/**
+ * A seeded realm user that authenticates successfully but lacks ROLE_ADMIN
+ * (`user` holds only ROLE_USER + default-roles-valtimo). Used by the API specs
+ * to exercise the Camel per-endpoint / per-profile role check: a valid JWT that
+ * does not carry the required authority is rejected by the route (mapped to 401
+ * by the global error handler), not by the resource-server filter. The valtimo
+ * demo realm uses username == password.
+ */
+export const WRONG_ROLE_USER = {
+    username: process.env.E2E_WRONG_ROLE_USERNAME ?? "user",
+    password: process.env.E2E_WRONG_ROLE_PASSWORD ?? "user",
+};
+
+/**
+ * Acquire a bearer access token for the public REST API via the OAuth2 password
+ * grant against the live Keycloak `valtimo` realm.
+ *
+ * Using a known user (`admin`) means the JWT carries the realm roles that the
+ * e2e app maps to authorities (`SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_AUTHORITIESCLAIMNAME=[realm_access][roles]`,
+ * audience `account`), which is what satisfies the Camel per-profile /
+ * per-endpoint role checks for the seeded BRP data.
+ */
+export async function fetchAccessToken(
+    request: APIRequestContext,
+    user: { username: string; password: string } = ADMIN_USER,
+): Promise<string> {
+    const res = await request.post(KEYCLOAK_TOKEN_URL, {
+        form: {
+            grant_type: "password",
+            client_id: OIDC_CLIENT_ID,
+            client_secret: OIDC_CLIENT_SECRET,
+            username: user.username,
+            password: user.password,
+        },
+    });
+    if (!res.ok()) {
+        throw new Error(
+            `Token request failed: ${res.status()} ${await res.text()}`,
+        );
+    }
+    const body = (await res.json()) as { access_token?: string };
+    if (!body.access_token) {
+        throw new Error("Token response did not contain an access_token");
+    }
+    return body.access_token;
+}
+
+type ApiFixtures = {
+    /** Raw token string, useful for negative/"wrong token" cases. */
+    accessToken: string;
+    /**
+     * APIRequestContext pre-configured with `baseURL` = the app and the
+     * `Authorization: Bearer <token>` header attached to every request.
+     */
+    apiContext: APIRequestContext;
+    /** Unauthenticated APIRequestContext against the app (for 401 cases). */
+    anonymousApiContext: APIRequestContext;
+};
+
+/**
+ * API test base. Specs that need a bearer-auth'd context use the `apiContext`
+ * fixture; `anonymousApiContext` covers the unauthenticated negative case.
+ *
+ * These specs do not touch the browser, so they ignore the saved storageState
+ * and the `chromium` project entirely (they live under tests/api/).
+ */
+export const test = base.extend<ApiFixtures>({
+    accessToken: async ({ playwright }, use) => {
+        const tokenContext = await playwrightRequest.newContext();
+        try {
+            const token = await fetchAccessToken(tokenContext);
+            await use(token);
+        } finally {
+            await tokenContext.dispose();
+        }
+    },
+    apiContext: async ({ playwright, accessToken }, use) => {
+        const context = await playwright.request.newContext({
+            baseURL: APP_BASE_URL,
+            extraHTTPHeaders: { Authorization: `Bearer ${accessToken}` },
+        });
+        await use(context);
+        await context.dispose();
+    },
+    anonymousApiContext: async ({ playwright }, use) => {
+        const context = await playwright.request.newContext({
+            baseURL: APP_BASE_URL,
+        });
+        await use(context);
+        await context.dispose();
+    },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -1,0 +1,32 @@
+import { test as base } from "@playwright/test";
+import { ADMIN_USER, STORAGE_STATE } from "./env";
+import { LoginPage } from "../pages/LoginPage";
+
+/**
+ * Setup helper used by the `setup` project in playwright.config.ts.
+ *
+ * Performs the real Keycloak login form flow once as `admin` and persists the
+ * resulting session (cookies/storage) to `.auth/admin.json` so the dependent
+ * projects can reuse the authenticated context without logging in per test.
+ */
+export async function globalLoginAndSaveState(
+    loginPage: LoginPage,
+    save: (path: string) => Promise<unknown>,
+): Promise<void> {
+    await loginPage.goto();
+    await loginPage.loginAs(ADMIN_USER.username, ADMIN_USER.password);
+    await save(STORAGE_STATE);
+}
+
+/**
+ * Fixture that exposes a ready `LoginPage` for specs that drive login/logout
+ * explicitly (the smoke spec). Most feature specs instead rely on the
+ * pre-saved `storageState` and never touch this fixture.
+ */
+export const test = base.extend<{ loginPage: LoginPage }>({
+    loginPage: async ({ page }, use) => {
+        await use(new LoginPage(page));
+    },
+});
+
+export { expect } from "@playwright/test";

--- a/e2e/fixtures/env.ts
+++ b/e2e/fixtures/env.ts
@@ -1,0 +1,37 @@
+/**
+ * Central configuration for the e2e suite.
+ *
+ * Values default to the local `docker-compose-e2e.yaml` published ports and the
+ * `valtimo` Keycloak realm, and can be overridden via environment variables for CI.
+ */
+
+export const APP_BASE_URL = process.env.E2E_BASE_URL ?? "http://localhost:8080";
+
+export const KEYCLOAK_BASE_URL =
+    process.env.E2E_KEYCLOAK_BASE_URL ?? "http://localhost:8082";
+
+export const KEYCLOAK_REALM = process.env.E2E_KEYCLOAK_REALM ?? "valtimo";
+
+export const KEYCLOAK_ISSUER = `${KEYCLOAK_BASE_URL}/auth/realms/${KEYCLOAK_REALM}`;
+
+export const KEYCLOAK_TOKEN_URL = `${KEYCLOAK_ISSUER}/protocol/openid-connect/token`;
+
+export const OIDC_CLIENT_ID = process.env.E2E_CLIENT_ID ?? "iko";
+
+export const OIDC_CLIENT_SECRET =
+    process.env.E2E_CLIENT_SECRET ?? "ThisIsNotASecret";
+
+/**
+ * Default browser-login user — seeded in the `valtimo` realm with ROLE_ADMIN.
+ * The header renders the OIDC `name` claim (full name) when present, otherwise
+ * the email; the `iko` client maps both into userinfo for this user.
+ */
+export const ADMIN_USER = {
+    username: process.env.E2E_ADMIN_USERNAME ?? "admin",
+    password: process.env.E2E_ADMIN_PASSWORD ?? "admin",
+    email: "admin@example.com",
+    fullName: "Asha Miller",
+};
+
+/** Where the authenticated browser storageState is persisted by the setup project. */
+export const STORAGE_STATE = ".auth/admin.json";

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,111 @@
+{
+    "name": "iko-e2e",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "iko-e2e",
+            "version": "1.0.0",
+            "devDependencies": {
+                "@playwright/test": "^1.49.0",
+                "@types/node": "^22.10.0",
+                "typescript": "^5.7.0"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+            "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "22.20.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+            "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.21.0"
+            }
+        },
+        "node_modules/fsevents": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/playwright": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+            "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "playwright-core": "1.61.1"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.61.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+            "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/undici-types": {
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "dev": true,
+            "license": "MIT"
+        }
+    }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,16 @@
+{
+    "name": "iko-e2e",
+    "version": "1.0.0",
+    "private": true,
+    "description": "Playwright end-to-end test suite for IKO (Admin UI + public REST API)",
+    "scripts": {
+        "test": "playwright test",
+        "report": "playwright show-report",
+        "typecheck": "tsc --noEmit"
+    },
+    "devDependencies": {
+        "@playwright/test": "^1.49.0",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+    }
+}

--- a/e2e/pages/AdpFormPage.ts
+++ b/e2e/pages/AdpFormPage.ts
@@ -1,0 +1,186 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+/**
+ * Page Object for the Aggregated Data Profile create modal (`add.html`, swapped
+ * into `#modal-container` as `#active-modal`) and the inline edit form on the
+ * detail page's General tab (`edit-panel.html`, `#profile-edit-form`).
+ *
+ * Field handling:
+ *  - `name` / `roles` are Carbon `cds-text-input` hosts; Playwright auto-pierces
+ *    their Shadow DOM, so we `.fill()` the inner input.
+ *  - `connectorInstanceId` / `connectorEndpointId` are `cds-select` hosts. The Add
+ *    form pre-selects the first option (the single seeded e2e instance/endpoint),
+ *    so by default no interaction is needed; `selectInstance`/`selectEndpoint`
+ *    drive them via the `.value` property + `cds-select-selected` event when an
+ *    explicit choice is required.
+ *  - `endpointTransform` / `resultTransform` are Ace editors backed by light-DOM
+ *    hidden `<textarea>`s (the Add form ships valid defaults `{}` and `.`). We
+ *    drive the Ace instance (`el._editor.setValue`) so the change listener syncs
+ *    the textarea the form submits.
+ *
+ * Create posts the modal form; the server replies with `HX-Trigger: close-modal`
+ * and pushes the new profile's detail URL, so `submitCreate()` waits for the modal
+ * to hide and the URL to land on the detail page. Edit submits the inline form and
+ * the server re-renders `#view-panel`, so `submitEdit()` waits for the PUT to
+ * complete and the detail page to re-render.
+ */
+export class AdpFormPage {
+    readonly modal: Locator;
+    readonly name: Locator;
+    readonly instanceSelect: Locator;
+    readonly endpointSelect: Locator;
+    readonly roles: Locator;
+    readonly saveButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.modal = page.locator("#active-modal");
+        this.name = this.modal.locator("cds-text-input[name='name'] input");
+        this.instanceSelect = this.modal.locator(
+            "cds-select[name='connectorInstanceId']",
+        );
+        this.endpointSelect = this.modal.locator(
+            "cds-select[name='connectorEndpointId']",
+        );
+        this.roles = this.modal.locator("cds-text-input[name='roles'] input");
+        this.saveButton = this.modal.locator(
+            "cds-modal-footer-button[type='submit']",
+        );
+    }
+
+    /**
+     * Fill the ADP create modal. The connector instance/endpoint selects default
+     * to the single seeded e2e instance/endpoint, so only name + roles are
+     * required; pass `connectorInstanceId`/`connectorEndpointId` to override.
+     */
+    async fillAdd(values: {
+        name: string;
+        roles?: string;
+        connectorInstanceId?: string;
+        connectorEndpointId?: string;
+        endpointTransform?: string;
+        resultTransform?: string;
+    }): Promise<void> {
+        await this.name.fill(values.name);
+        await this.roles.fill(values.roles ?? "ROLE_ADMIN");
+        if (values.connectorInstanceId !== undefined) {
+            await this.selectInstance(values.connectorInstanceId);
+        }
+        if (values.connectorEndpointId !== undefined) {
+            await this.selectEndpoint(values.connectorEndpointId);
+        }
+        if (values.endpointTransform !== undefined) {
+            await this.setAceValue(
+                "#endpointTransform-editor-add",
+                "#endpointTransformCodeAdd",
+                values.endpointTransform,
+            );
+        }
+        if (values.resultTransform !== undefined) {
+            await this.setAceValue(
+                "#result-transform-editor-add",
+                "#resultTransformCodeAdd",
+                values.resultTransform,
+            );
+        }
+    }
+
+    /**
+     * Set the connector-instance select and fire the change event the form's
+     * endpoint-reload HTMX trigger listens for.
+     */
+    async selectInstance(connectorInstanceId: string): Promise<void> {
+        await this.instanceSelect.evaluate((el, value) => {
+            (el as unknown as { value: string }).value = value;
+            el.dispatchEvent(
+                new CustomEvent("cds-select-selected", { bubbles: true }),
+            );
+        }, connectorInstanceId);
+    }
+
+    /** Set the connector-endpoint select value. */
+    async selectEndpoint(connectorEndpointId: string): Promise<void> {
+        await this.endpointSelect.evaluate((el, value) => {
+            (el as unknown as { value: string }).value = value;
+            el.dispatchEvent(
+                new CustomEvent("cds-select-selected", { bubbles: true }),
+            );
+        }, connectorEndpointId);
+    }
+
+    /** Submit the create modal and wait for it to close and the detail page to load. */
+    async submitCreate(): Promise<void> {
+        await this.saveButton.click();
+        // close-modal removes the modal's `open` attribute; create also pushes the
+        // new profile's detail URL into the address bar.
+        await this.page.waitForURL(
+            /\/admin\/aggregated-data-profiles\/[0-9a-f-]+/,
+        );
+        await expect(this.modal).toBeHidden();
+    }
+
+    /**
+     * Drive an Ace editor (light-DOM textarea sync) so the submitted form carries
+     * the value.
+     */
+    private async setAceValue(
+        editorSelector: string,
+        textareaSelector: string,
+        value: string,
+    ): Promise<void> {
+        const editor = this.page.locator(editorSelector);
+        await expect(editor).toHaveClass(/ace_editor/);
+        await editor.evaluate((el, v) => {
+            const ace = (
+                el as unknown as {
+                    _editor?: { setValue: (val: string, cursor?: number) => void };
+                }
+            )._editor;
+            if (!ace) {
+                throw new Error(`Ace editor not initialised on ${el.id}`);
+            }
+            ace.setValue(v, -1);
+        }, value);
+        await expect(this.page.locator(textareaSelector)).toHaveValue(value);
+    }
+}
+
+/**
+ * Page Object for the inline ADP edit form on the detail page General tab.
+ *
+ * The form (`#profile-edit-form`) lives inside `#profile-edit`; its only freely
+ * editable field on a DRAFT profile is `roles` (name is immutable, the
+ * instance/endpoint selects are populated from the existing profile). Submitting
+ * via `#profile-save-btn` issues a PUT; the server re-renders `#view-panel`, so we
+ * wait for the PUT response and the re-rendered detail page.
+ */
+export class AdpEditForm {
+    readonly form: Locator;
+    readonly roles: Locator;
+    readonly saveButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.form = page.locator("#profile-edit-form");
+        this.roles = this.form.locator("cds-text-input[name='roles'] input");
+        this.saveButton = page.locator("#profile-save-btn");
+    }
+
+    /** Replace the roles value on the edit form. */
+    async setRoles(roles: string): Promise<void> {
+        await expect(this.roles).toBeVisible();
+        await this.roles.fill(roles);
+    }
+
+    /** Submit the edit form and wait for the PUT + detail-page re-render. */
+    async submit(): Promise<void> {
+        const put = this.page.waitForResponse(
+            (res) =>
+                res.request().method() === "PUT" &&
+                res.url().includes("/admin/aggregated-data-profiles") &&
+                res.ok(),
+        );
+        await this.saveButton.click();
+        await put;
+        // The re-rendered detail page re-mounts the General tab edit form.
+        await expect(this.page.locator("#profile-edit-form")).toBeVisible();
+    }
+}

--- a/e2e/pages/AdpListPage.ts
+++ b/e2e/pages/AdpListPage.ts
@@ -1,0 +1,131 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { APP_BASE_URL } from "../fixtures/env";
+
+/**
+ * Page Object for the Aggregated Data Profiles list view
+ * (`/admin/aggregated-data-profiles`).
+ *
+ * Anchors on the exact same stable host IDs as the Connectors list page
+ * (`#profile-table`, `#search-bar`, `#search-results`, `#active-filter-toggle`,
+ * `#pagination-container`) — `list.html` is shared between both flows, so the
+ * selector contract is identical and intentionally mirrored from
+ * `ConnectorListPage`. Only the `/filter` URL differs.
+ *
+ * HTMX wiring this POM cooperates with (see list.html):
+ *  - `#search-bar` filters via `hx-trigger="input changed delay:600ms"`, swapping
+ *    `#search-results` (outerHTML) plus an out-of-band `#pagination-container`.
+ *  - `#pagination-container` reacts to `cds-pagination-changed-current`, swapping
+ *    `#search-results`.
+ * Because `#search-results` is replaced (outerHTML), helpers wait for the matching
+ * `/filter` response and re-assert the expected post-condition rather than relying
+ * on a fixed timeout.
+ */
+export class AdpListPage {
+    readonly table: Locator;
+    readonly searchBar: Locator;
+    readonly results: Locator;
+    readonly rows: Locator;
+    readonly pagination: Locator;
+    readonly addButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.table = page.locator("#profile-table");
+        // The Carbon search host renders its <input> in Shadow DOM; target the
+        // inner input so .fill() works (the host carries the HTMX wiring).
+        this.searchBar = page.locator("#search-bar input");
+        this.results = page.locator("#search-results");
+        this.rows = page.locator(
+            "#search-results cds-table-row.app--table-row-clickable",
+        );
+        this.pagination = page.locator("#pagination-container");
+        // The list page only has one primary "Add new ..." button in the toolbar.
+        this.addButton = page.locator("#profile-table cds-button[hx-target='#modal-container']");
+    }
+
+    /** Navigate to the ADP list and wait for the table to render. */
+    async goto(): Promise<void> {
+        await this.page.goto(`${APP_BASE_URL}/admin/aggregated-data-profiles`);
+        await expect(this.table).toBeVisible();
+        await expect(this.results).toBeAttached();
+    }
+
+    /** Number of clickable profile rows currently rendered. */
+    async rowCount(): Promise<number> {
+        return this.rows.count();
+    }
+
+    /** True when a clickable row whose name cell matches `name` is present. */
+    async hasRowNamed(name: string): Promise<boolean> {
+        return (
+            (await this.rows.filter({ hasText: name }).count()) > 0
+        );
+    }
+
+    /**
+     * Type into the search bar and wait for the debounced (600ms) HTMX swap to
+     * settle. We wait for the `/filter` response then re-attach to the swapped
+     * results body.
+     */
+    async searchFor(term: string): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        await this.searchBar.fill(term);
+        await swap;
+    }
+
+    /** Clear the search bar and wait for the unfiltered list to come back. */
+    async clearSearch(): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        await this.searchBar.fill("");
+        await swap;
+    }
+
+    /** Drive the pagination control to navigate to 1-based page `n`. */
+    async goToPage(n: number): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        // cds-pagination exposes a `page` property and emits
+        // `cds-pagination-changed-current`; set the property and dispatch the
+        // event the HTMX trigger listens for.
+        await this.pagination.evaluate((el, page) => {
+            (el as unknown as { page: number }).page = page;
+            el.dispatchEvent(
+                new CustomEvent("cds-pagination-changed-current", {
+                    bubbles: true,
+                    detail: { page },
+                }),
+            );
+        }, n);
+        await swap;
+    }
+
+    /** Open the detail page for the row whose name cell matches `name`. */
+    async openRow(name: string): Promise<void> {
+        await this.rows.filter({ hasText: name }).first().click();
+        await this.page.waitForURL(
+            /\/admin\/aggregated-data-profiles\/[0-9a-f-]+/,
+        );
+    }
+
+    /**
+     * Click "Add new 'Aggregated Data Profile'"; the create modal is swapped into
+     * #modal-container.
+     */
+    async openAddModal(): Promise<void> {
+        await this.addButton.click();
+        await expect(this.page.locator("#active-modal")).toBeVisible();
+    }
+
+    /**
+     * Await the `#search-results` outerHTML swap that follows a search/pagination
+     * action. Resolves once the matching `/filter` response is observed.
+     */
+    private async waitForFilterSwap(): Promise<void> {
+        await this.page.waitForResponse(
+            (res) =>
+                res
+                    .url()
+                    .includes("/admin/aggregated-data-profiles/filter") &&
+                res.ok(),
+        );
+        await expect(this.results).toBeAttached();
+    }
+}

--- a/e2e/pages/ConnectorFormPage.ts
+++ b/e2e/pages/ConnectorFormPage.ts
@@ -1,0 +1,111 @@
+import { expect, Locator, Page } from "@playwright/test";
+
+/**
+ * Page Object for the Connector create modal and the Connector Instance create
+ * modal (both swapped into `#modal-container` as `#active-modal`).
+ *
+ * Field handling:
+ *  - `name` / `reference` / `apiSpecificationUrl` are Carbon `cds-text-input`
+ *    hosts; Playwright auto-pierces their Shadow DOM, so we `.fill()` the host.
+ *  - `connectorCode` is an Ace editor (`#connectorCodeEditor`) that syncs into a
+ *    light-DOM hidden `<textarea id="connectorCodeField" name="connectorCode">`.
+ *    Ace overwrites the textarea on every `change`, so we drive the Ace instance
+ *    (`el._editor.setValue`) rather than writing the textarea directly — that
+ *    fires the change listener and leaves the textarea holding our value.
+ *
+ * Submit posts the modal form and the server replies with `HX-Trigger: close-modal`.
+ * admin-ui.js handles that event by removing the modal's `open` attribute (it does
+ * not delete the element), so `submit()` waits for the modal to become hidden.
+ */
+export class ConnectorFormPage {
+    readonly modal: Locator;
+    readonly name: Locator;
+    readonly reference: Locator;
+    readonly apiSpecificationUrl: Locator;
+    readonly saveButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.modal = page.locator("#active-modal");
+        // Carbon `cds-text-input` renders its real <input> in Shadow DOM; the host
+        // carries the stable name=. Target the inner input so .fill() works.
+        this.name = this.modal.locator("cds-text-input[name='name'] input");
+        this.reference = this.modal.locator(
+            "cds-text-input[name='reference'] input",
+        );
+        this.apiSpecificationUrl = this.modal.locator(
+            "cds-text-input[name='apiSpecificationUrl'] input",
+        );
+        this.saveButton = this.modal.locator(
+            "cds-modal-footer-button[type='submit']",
+        );
+    }
+
+    /** Fill the connector create modal (name, reference, valid connector code). */
+    async fillConnector(values: {
+        name: string;
+        reference: string;
+        connectorCode?: string;
+    }): Promise<void> {
+        await this.name.fill(values.name);
+        await this.reference.fill(values.reference);
+        const code = values.connectorCode ?? defaultConnectorCode(values.reference);
+        await this.setConnectorCode(code);
+    }
+
+    /** Fill the connector instance create modal (name, reference, optional URL). */
+    async fillInstance(values: {
+        name: string;
+        reference: string;
+        apiSpecificationUrl?: string;
+    }): Promise<void> {
+        await this.name.fill(values.name);
+        await this.reference.fill(values.reference);
+        if (values.apiSpecificationUrl !== undefined) {
+            await this.apiSpecificationUrl.fill(values.apiSpecificationUrl);
+        }
+    }
+
+    /**
+     * Write into the connector-code Ace editor and let it sync the hidden
+     * textarea that the form submits.
+     */
+    async setConnectorCode(code: string): Promise<void> {
+        const editor = this.page.locator("#connectorCodeEditor");
+        await expect(editor).toHaveClass(/ace_editor/);
+        await editor.evaluate((el, value) => {
+            const ace = (el as unknown as { _editor?: { setValue: (v: string, c?: number) => void } })
+                ._editor;
+            if (!ace) {
+                throw new Error("Ace editor not initialised on #connectorCodeEditor");
+            }
+            ace.setValue(value, -1);
+        }, code);
+        // Confirm the sync reached the submitted textarea.
+        await expect(this.page.locator("#connectorCodeField")).toHaveValue(code);
+    }
+
+    /** Submit the modal form and wait for the close-modal trigger to hide it. */
+    async submit(): Promise<void> {
+        await this.saveButton.click();
+        // close-modal removes the `open` attribute; the modal becomes hidden.
+        await expect(this.modal).toBeHidden();
+    }
+}
+
+/**
+ * Minimal valid connector code whose single route URI matches `reference` — the
+ * server validates that `direct:iko:connector:{tag}` equals the connector tag
+ * before persisting.
+ */
+export function defaultConnectorCode(reference: string): string {
+    return [
+        "- route:",
+        `    id: "direct:iko:connector:${reference}"`,
+        "    errorHandler:",
+        "        noErrorHandler: { }",
+        "    from:",
+        `        uri: "direct:iko:connector:${reference}"`,
+        "        steps:",
+        '            - log: "e2e created connector"',
+    ].join("\n");
+}

--- a/e2e/pages/ConnectorListPage.ts
+++ b/e2e/pages/ConnectorListPage.ts
@@ -1,0 +1,124 @@
+import { expect, Locator, Page } from "@playwright/test";
+import { APP_BASE_URL } from "../fixtures/env";
+
+/**
+ * Page Object for the Connectors list view (`/admin/connectors`).
+ *
+ * Anchors on the stable host IDs shared by the Connector and ADP list pages
+ * (`#profile-table`, `#search-bar`, `#search-results`, `#active-filter-toggle`,
+ * `#pagination-container`). The interactive Carbon inputs live in Shadow DOM;
+ * Playwright auto-pierces, so we drive them through the host locators.
+ *
+ * HTMX wiring this POM has to cooperate with:
+ *  - `#search-bar` filters via `hx-trigger="input changed delay:600ms"`, swapping
+ *    `#search-results` (outerHTML) plus an out-of-band `#pagination-container`.
+ *  - `#pagination-container` reacts to `cds-pagination-changed-current` /
+ *    `cds-page-sizes-select-changed`, swapping `#search-results`.
+ * Because `#search-results` is replaced (outerHTML), helpers wait for the swap to
+ * settle by re-locating it and asserting the expected post-condition rather than
+ * relying on a fixed timeout.
+ */
+export class ConnectorListPage {
+    readonly table: Locator;
+    readonly searchBar: Locator;
+    readonly results: Locator;
+    readonly rows: Locator;
+    readonly pagination: Locator;
+    readonly addButton: Locator;
+
+    constructor(private readonly page: Page) {
+        this.table = page.locator("#profile-table");
+        // The Carbon search host renders its <input> in Shadow DOM; target the
+        // inner input so .fill() works (the host carries the HTMX wiring).
+        this.searchBar = page.locator("#search-bar input");
+        this.results = page.locator("#search-results");
+        this.rows = page.locator("#search-results cds-table-row.app--table-row-clickable");
+        this.pagination = page.locator("#pagination-container");
+        this.addButton = page.locator("#profile-table cds-button[kind='primary']");
+    }
+
+    /** Navigate to the Connectors list and wait for the table to render. */
+    async goto(): Promise<void> {
+        await this.page.goto(`${APP_BASE_URL}/admin/connectors`);
+        await expect(this.table).toBeVisible();
+        await expect(this.results).toBeAttached();
+    }
+
+    /** Number of clickable connector rows currently rendered. */
+    async rowCount(): Promise<number> {
+        return this.rows.count();
+    }
+
+    /** True when a row whose name cell matches `name` is present. */
+    async hasRowNamed(name: string): Promise<boolean> {
+        return (
+            (await this.results
+                .locator("cds-table-row", { hasText: name })
+                .count()) > 0
+        );
+    }
+
+    /**
+     * Type into the search bar and wait for the debounced (600ms) HTMX swap to
+     * settle. We wait for the `/filter` response and then for the results body to
+     * reflect the search (either the expected row or the "No result found" row).
+     */
+    async searchFor(term: string): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        await this.searchBar.fill(term);
+        await swap;
+    }
+
+    /** Clear the search bar and wait for the unfiltered list to come back. */
+    async clearSearch(): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        await this.searchBar.fill("");
+        await swap;
+    }
+
+    /** Drive the pagination control to navigate to 1-based page `n`. */
+    async goToPage(n: number): Promise<void> {
+        const swap = this.waitForFilterSwap();
+        // cds-pagination exposes a `page` property and emits
+        // `cds-pagination-changed-current`; set the property and dispatch the
+        // event the HTMX trigger listens for.
+        await this.pagination.evaluate((el, page) => {
+            (el as unknown as { page: number }).page = page;
+            el.dispatchEvent(
+                new CustomEvent("cds-pagination-changed-current", {
+                    bubbles: true,
+                    detail: { page },
+                }),
+            );
+        }, n);
+        await swap;
+    }
+
+    /** Open the detail page for the row whose name cell matches `name`. */
+    async openRow(name: string): Promise<void> {
+        await this.results
+            .locator("cds-table-row", { hasText: name })
+            .first()
+            .click();
+        await this.page.waitForURL(/\/admin\/connectors\/[0-9a-f-]+/);
+    }
+
+    /** Click "Add connector"; the create modal is swapped into #modal-container. */
+    async openAddModal(): Promise<void> {
+        await this.addButton.click();
+        await expect(this.page.locator("#active-modal")).toBeVisible();
+    }
+
+    /**
+     * Await the `#search-results` outerHTML swap that follows a search/pagination
+     * action. Resolves once the matching `/filter` response is observed.
+     */
+    private async waitForFilterSwap(): Promise<void> {
+        await this.page.waitForResponse(
+            (res) =>
+                res.url().includes("/admin/connectors/filter") && res.ok(),
+        );
+        // Re-attach to the freshly swapped results body.
+        await expect(this.results).toBeAttached();
+    }
+}

--- a/e2e/pages/LoginPage.ts
+++ b/e2e/pages/LoginPage.ts
@@ -1,0 +1,42 @@
+import { expect, Page } from "@playwright/test";
+import { APP_BASE_URL } from "../fixtures/env";
+
+/**
+ * Page Object for the Admin UI authentication flow.
+ *
+ * Covers the Keycloak login form (`#username`, `#password`, `#kc-login`) and the
+ * post-login `/admin` landing page + JS-driven logout (`#logout-link` → POST /logout).
+ */
+export class LoginPage {
+    constructor(private readonly page: Page) {}
+
+    /** Navigate to `/admin`; unauthenticated visits redirect to the Keycloak login form. */
+    async goto(): Promise<void> {
+        await this.page.goto(`${APP_BASE_URL}/admin`);
+    }
+
+    /** True when the current page is the Keycloak login form. */
+    async isOnKeycloakLogin(): Promise<boolean> {
+        return (await this.page.locator("#username").count()) > 0;
+    }
+
+    /** Fill and submit the Keycloak login form, then wait for the `/admin` landing page. */
+    async loginAs(user: string, password: string): Promise<void> {
+        await this.page.waitForSelector("#username");
+        await this.page.locator("#username").fill(user);
+        await this.page.locator("#password").fill(password);
+        await Promise.all([
+            this.page.waitForURL(`${APP_BASE_URL}/admin**`),
+            this.page.locator("#kc-login").click(),
+        ]);
+        await expect(this.page.locator("#logout-link")).toBeVisible();
+    }
+
+    /** Click `#logout-link`; admin-ui.js builds a POST form to /logout with the CSRF token. */
+    async logout(): Promise<void> {
+        await Promise.all([
+            this.page.waitForURL(/\/(admin|auth\/realms)/),
+            this.page.locator("#logout-link").click(),
+        ]);
+    }
+}

--- a/e2e/pages/LoginPage.ts
+++ b/e2e/pages/LoginPage.ts
@@ -32,11 +32,31 @@ export class LoginPage {
         await expect(this.page.locator("#logout-link")).toBeVisible();
     }
 
-    /** Click `#logout-link`; admin-ui.js builds a POST form to /logout with the CSRF token. */
+    /** Open the header switcher panel and click `#logout-link`; admin-ui.js builds a POST form to /logout with the CSRF token. */
     async logout(): Promise<void> {
-        await Promise.all([
-            this.page.waitForURL(/\/(admin|auth\/realms)/),
-            this.page.locator("#logout-link").click(),
-        ]);
+        // #logout-link lives inside the collapsed cds-header-panel#switcher-panel
+        // (positioned off-canvas until expanded). The toggle action sets
+        // expanded="true" on the panel, but Carbon hydration can drop an early
+        // click — so poll: click the toggle only while the panel is collapsed,
+        // and wait until it reports expanded before clicking logout. Clicking
+        // only when collapsed avoids toggling it back closed.
+        const panel = this.page.locator("#switcher-panel");
+        const toggle = this.page.locator(
+            'cds-header-global-action[panel-id="switcher-panel"]',
+        );
+        await expect(async () => {
+            if ((await panel.getAttribute("expanded")) !== "true") {
+                await toggle.click();
+            }
+            await expect(panel).toHaveAttribute("expanded", "true", {
+                timeout: 1000,
+            });
+        }).toPass({ timeout: 15000 });
+        await this.page.locator("#logout-link").click();
+        // Logout is a multi-hop chain: POST /logout -> Keycloak end-session ->
+        // post-logout redirect to /admin -> unauthenticated -> Keycloak login
+        // form. Wait for the Keycloak login form (#username) — the definitive
+        // logged-out state — rather than racing intermediate URLs.
+        await this.page.waitForSelector("#username");
     }
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -24,7 +24,7 @@ export default defineConfig({
     use: {
         baseURL: APP_BASE_URL,
         trace: "on-first-retry",
-        screenshot: "only-on-failure",
+        screenshot: "on",
         video: "retain-on-failure",
     },
     projects: [

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -40,15 +40,24 @@ export default defineConfig({
             use: { ...devices["Desktop Chrome"] },
         },
         {
-            // Authenticated feature specs (connectors, adp) reuse the saved session.
-            // Login smoke is excluded so it does not run pre-authenticated.
+            // Authenticated Admin UI feature specs (connectors, adp) reuse the
+            // saved session. Login smoke and the headless API specs are excluded so
+            // they do not run pre-authenticated in a browser.
             name: "chromium",
-            testIgnore: [/auth\.setup\.ts/, /admin\/login\.spec\.ts/],
+            testMatch: /admin\/.*\.spec\.ts/,
+            testIgnore: [/admin\/login\.spec\.ts/],
             use: {
                 ...devices["Desktop Chrome"],
                 storageState: STORAGE_STATE,
             },
             dependencies: ["setup"],
+        },
+        {
+            // Public REST API specs — pure HTTP, no browser/session. Acquire a JWT
+            // via the password-grant fixture (fixtures/api-token.ts) and hit the
+            // secured `/endpoints` and `/aggregated-data-profiles` routes.
+            name: "api",
+            testMatch: /api\/.*\.spec\.ts/,
         },
     ],
 });

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig, devices } from "@playwright/test";
+import { APP_BASE_URL, STORAGE_STATE } from "./fixtures/env";
+
+/**
+ * Playwright configuration for the IKO e2e suite.
+ *
+ * The full stack (app + Postgres + Redis + Keycloak) is owned by
+ * `docker-compose-e2e.yaml`; CI brings it up and gates on the actuator readiness
+ * probe before invoking `playwright test`. No `webServer` block is configured, so
+ * the runner always targets an already-running stack at `baseURL`.
+ *
+ * The `setup` project logs in once against live Keycloak and saves the
+ * authenticated storageState; the browser projects depend on it and reuse the
+ * session via `storageState`. The smoke login spec drives login/logout itself
+ * and therefore runs without a saved storageState.
+ */
+export default defineConfig({
+    testDir: "tests",
+    fullyParallel: true,
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 1 : 0,
+    workers: process.env.CI ? 1 : undefined,
+    reporter: [["html", { outputFolder: "playwright-report", open: "never" }]],
+    use: {
+        baseURL: APP_BASE_URL,
+        trace: "on-first-retry",
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+    },
+    projects: [
+        {
+            name: "setup",
+            testMatch: /auth\.setup\.ts/,
+            use: { ...devices["Desktop Chrome"] },
+        },
+        {
+            // Smoke login/logout spec — drives the auth flow directly, no saved state.
+            name: "smoke",
+            testMatch: /admin\/login\.spec\.ts/,
+            use: { ...devices["Desktop Chrome"] },
+        },
+        {
+            // Authenticated feature specs (connectors, adp) reuse the saved session.
+            // Login smoke is excluded so it does not run pre-authenticated.
+            name: "chromium",
+            testIgnore: [/auth\.setup\.ts/, /admin\/login\.spec\.ts/],
+            use: {
+                ...devices["Desktop Chrome"],
+                storageState: STORAGE_STATE,
+            },
+            dependencies: ["setup"],
+        },
+    ],
+});

--- a/e2e/seed/V9999.01.01.1__e2e_baseline.sql
+++ b/e2e/seed/V9999.01.01.1__e2e_baseline.sql
@@ -212,3 +212,91 @@ VALUES
     ('e2e00004-0000-0000-0000-000000000012', 'e2e-adp-12', '1.0.0', TRUE, 'FINAL',
      'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
      '{}', '.', 'ROLE_ADMIN', FALSE, 0);
+
+-- ============================================================================
+-- Phase 5: BRP personen connector + instance + endpoint + ADP (API flow)
+-- ============================================================================
+-- The public REST API specs (`/endpoints/...` and `/aggregated-data-profiles/...`)
+-- need a connector whose route makes a real external call. This block seeds a
+-- self-contained BRP "personen" connector that, when invoked, POSTs a
+-- RaadpleegMetBurgerservicenummer search to the in-network personen mock
+-- (`haalcentraal-personen:5010`) via Camel `rest-openapi`, using the bundled
+-- OpenAPI document mounted at file:/openapi-specs/haalcentraal-brp-personen.yaml.
+--
+-- The connector route is deliberately simpler than the production
+-- brp-wsgateway template (no Keycloak token exchange / mTLS): the e2e mock is
+-- plain HTTP and unauthenticated. The route builds a minimal valid PersonenQuery
+-- body so the GET `/endpoints/.../Personen` route resolves to a real 200 from the
+-- mock. The mock answers any valid query with HTTP 200 and a `{ "type", "personen" }`
+-- envelope (an unknown BSN simply yields an empty `personen` array), so the spec
+-- can assert on the envelope without depending on a specific seeded BSN.
+--
+-- The connector tag (`e2e-brp`), instance tag (`e2e-brp-instance`) and operation
+-- (`Personen`) are the path segments the `/endpoints/{connector}/{config}/{operation}`
+-- route is invoked with.
+INSERT INTO connector (id, name, tag, version, is_active, status, connector_code)
+VALUES ('e2e00005-0000-0000-0000-000000000001', 'e2e-brp', 'e2e-brp', '1.0.0', TRUE, 'FINAL',
+        '- route:
+    id: "direct:iko:connector:e2e-brp"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-brp"
+        steps:
+            - removeHeaders: "CamelHttp*"
+            - setHeader:
+                name: "CamelHttpMethod"
+                constant: "POST"
+            - setHeader:
+                name: "Content-Type"
+                constant: "application/json; charset=utf-8"
+            - setHeader:
+                name: "Accept"
+                constant: "application/json; charset=utf-8"
+            - setBody:
+                constant: "{\"type\":\"RaadpleegMetBurgerservicenummer\",\"burgerservicenummer\":[\"999993653\"],\"fields\":[\"burgerservicenummer\",\"naam\"]}"
+            - toD:
+                uri: "language:groovy:\"rest-openapi:${variable.configProperties.apiSpecificationUrl}#${variable.operation}?host=${variable.configProperties.host}\""
+            - unmarshal:
+                json: { }');
+
+-- Instance config (host + apiSpecificationUrl) stored as AES-GCM ciphertext,
+-- encrypted with the fixed e2e IKO_CRYPTO_KEY that docker-compose-e2e.yaml sets.
+-- Regenerate these values with e2e/seed/encrypt-config.mjs if the key changes.
+INSERT INTO connector_instance (id, name, connector_id, tag, api_specification_url)
+VALUES ('e2e00006-0000-0000-0000-000000000001', 'e2e-brp-instance',
+        'e2e00005-0000-0000-0000-000000000001', 'e2e-brp-instance', NULL);
+
+INSERT INTO connector_instance_config (connector_instance_id, key, value)
+VALUES
+    -- host: http://haalcentraal-personen:5010
+    ('e2e00006-0000-0000-0000-000000000001', 'host',
+     '4APAMKuUmMWgYj/gZSNb0k8DLyVwAyx2WY6j6QO2EDNBtKgyT2VuH2E8iZWu5yw5iifHbL8YvZY2lA97TA=='),
+    -- apiSpecificationUrl: file:/openapi-specs/haalcentraal-brp-personen.yaml
+    ('e2e00006-0000-0000-0000-000000000001', 'apiSpecificationUrl',
+     'nWHGOMQbKmYpB2cyASAVUAD8G95PcwtaQUpEaBsgXAUlAIeTnDO4BiUq1Jblm4wzDVM/oH1Uwj1y/X1epjS+7gB6pOk+V2GK3l2uBKXr');
+
+INSERT INTO connector_endpoint (id, name, connector_id, operation)
+VALUES ('e2e00007-0000-0000-0000-000000000001', 'Personen',
+        'e2e00005-0000-0000-0000-000000000001', 'Personen');
+
+-- connector_endpoint_role grants ROLE_ADMIN on the BRP endpoint+instance pair so
+-- the Camel per-endpoint role check (EndpointAuthRouteBuilder) passes for `admin`.
+INSERT INTO connector_endpoint_role (id, connector_endpoint_id, connector_instance_id, role)
+VALUES ('e2e00008-0000-0000-0000-000000000001',
+        'e2e00007-0000-0000-0000-000000000001',
+        'e2e00006-0000-0000-0000-000000000001',
+        'ROLE_ADMIN');
+
+-- An ADP exposing the same BRP endpoint via `/aggregated-data-profiles/{name}`.
+-- roles=ROLE_ADMIN satisfies the per-profile Camel check (AuthRoute); the result
+-- transform passes the mock envelope through unchanged ('.').
+INSERT INTO aggregated_data_profile (
+    id, name, version, is_active, status,
+    connector_instance_id, connector_endpoint_id,
+    endpoint_transform, transform, roles, cache_enabled, cache_ttl
+)
+VALUES
+    ('e2e00009-0000-0000-0000-000000000001', 'e2e-brp-personen', '1.0.0', TRUE, 'FINAL',
+     'e2e00006-0000-0000-0000-000000000001', 'e2e00007-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0);

--- a/e2e/seed/V9999.01.01.1__e2e_baseline.sql
+++ b/e2e/seed/V9999.01.01.1__e2e_baseline.sql
@@ -1,0 +1,150 @@
+-- ============================================================================
+-- e2e baseline seed (mounted Flyway migration)
+-- ============================================================================
+-- This file is NOT part of the application's classpath migrations. It is mounted
+-- into the e2e app container at /seed and applied via
+--   SPRING_FLYWAY_LOCATIONS=classpath:db/migration,filesystem:/seed
+-- (see docker-compose-e2e.yaml). Keeping it out of src/ guarantees it can never
+-- run against a production database.
+--
+-- It mirrors the existing test-seed pattern
+-- (src/test/resources/db/migration-test/V2026.01.08.1__adp_test_seed_data.sql):
+-- plain INSERTs into connector / connector_instance / connector_endpoint.
+--
+-- Purpose for Phase 3: provide enough baseline Connector rows so the Connectors
+-- list spans multiple pages regardless of which create/edit specs ran first, so
+-- the pagination assertions are order-independent. The list defaults to
+-- "active only" and sorts by name ascending, so every baseline connector is
+-- inserted with is_active = TRUE, status = FINAL and a zero-padded numeric name
+-- suffix that sorts deterministically.
+--
+-- All ids are fixed UUIDs (namespaced under the e2e0... prefix) so the data is
+-- reproducible across runs. Names/tags are namespaced `e2e-conn-*` so they are
+-- easy to filter on and never collide with UI-created rows.
+--
+-- Connector baseline rows carry valid connector code (a single direct route
+-- whose URI matches the connector tag) so they pass any later validation, but
+-- Phase 3 only asserts on list/search/paginate, not on route execution.
+
+INSERT INTO connector (id, name, tag, version, is_active, status, connector_code)
+VALUES
+    ('e2e00001-0000-0000-0000-000000000001', 'e2e-conn-01', 'e2e-conn-01', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-01"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-01"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000002', 'e2e-conn-02', 'e2e-conn-02', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-02"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-02"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000003', 'e2e-conn-03', 'e2e-conn-03', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-03"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-03"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000004', 'e2e-conn-04', 'e2e-conn-04', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-04"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-04"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000005', 'e2e-conn-05', 'e2e-conn-05', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-05"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-05"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000006', 'e2e-conn-06', 'e2e-conn-06', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-06"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-06"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000007', 'e2e-conn-07', 'e2e-conn-07', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-07"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-07"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000008', 'e2e-conn-08', 'e2e-conn-08', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-08"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-08"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000009', 'e2e-conn-09', 'e2e-conn-09', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-09"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-09"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000010', 'e2e-conn-10', 'e2e-conn-10', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-10"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-10"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000011', 'e2e-conn-11', 'e2e-conn-11', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-11"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-11"
+        steps:
+            - log: "e2e baseline connector"'),
+    ('e2e00001-0000-0000-0000-000000000012', 'e2e-conn-12', 'e2e-conn-12', '1.0.0', TRUE, 'FINAL',
+     '- route:
+    id: "direct:iko:connector:e2e-conn-12"
+    errorHandler:
+        noErrorHandler: { }
+    from:
+        uri: "direct:iko:connector:e2e-conn-12"
+        steps:
+            - log: "e2e baseline connector"');
+
+-- One baseline instance + endpoint on the first connector. Not strictly required
+-- for the Connectors list/search/paginate coverage, but gives the detail page a
+-- populated instance/endpoint table and a stable instance for later phases to
+-- reference.
+INSERT INTO connector_instance (id, name, connector_id, tag, api_specification_url)
+VALUES ('e2e00002-0000-0000-0000-000000000001', 'e2e-instance-01',
+        'e2e00001-0000-0000-0000-000000000001', 'e2e-instance-01', NULL);
+
+INSERT INTO connector_endpoint (id, name, connector_id, operation)
+VALUES ('e2e00003-0000-0000-0000-000000000001', 'e2e-endpoint-01',
+        'e2e00001-0000-0000-0000-000000000001', 'GetThings');

--- a/e2e/seed/V9999.01.01.1__e2e_baseline.sql
+++ b/e2e/seed/V9999.01.01.1__e2e_baseline.sql
@@ -148,3 +148,67 @@ VALUES ('e2e00002-0000-0000-0000-000000000001', 'e2e-instance-01',
 INSERT INTO connector_endpoint (id, name, connector_id, operation)
 VALUES ('e2e00003-0000-0000-0000-000000000001', 'e2e-endpoint-01',
         'e2e00001-0000-0000-0000-000000000001', 'GetThings');
+
+-- ============================================================================
+-- Phase 4: baseline Aggregated Data Profiles
+-- ============================================================================
+-- Provide enough baseline ADP rows (>= one page of 10) so the ADP list spans
+-- multiple pages regardless of which create/edit specs ran first, making the
+-- pagination assertions order-independent. Mirrors the Connector baseline above.
+--
+-- Every profile references the single seeded connector instance + endpoint
+-- (e2e00002-...01 / e2e00003-...01) so create/edit specs can reuse the same
+-- known connectorInstanceId / connectorEndpointId the Add form pre-selects.
+--
+-- The ADP list defaults to "active only" and sorts by name ascending, so each
+-- profile is inserted with is_active = TRUE and a zero-padded numeric name suffix
+-- that sorts deterministically. They are status = FINAL so they are stable
+-- (no Delete action, immutable) and never collide with the DRAFT rows the
+-- create/edit specs add on top. (name, version) is unique and only one active
+-- version per name is allowed; each baseline name is distinct so all stay active.
+--
+-- endpoint_transform / transform carry valid JQ (matching the Add form defaults:
+-- '{}' for the endpoint transform, '.' for the result transform). roles is set
+-- to ROLE_ADMIN, a realm role the e2e `admin` user holds.
+INSERT INTO aggregated_data_profile (
+    id, name, version, is_active, status,
+    connector_instance_id, connector_endpoint_id,
+    endpoint_transform, transform, roles, cache_enabled, cache_ttl
+)
+VALUES
+    ('e2e00004-0000-0000-0000-000000000001', 'e2e-adp-01', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000002', 'e2e-adp-02', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000003', 'e2e-adp-03', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000004', 'e2e-adp-04', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000005', 'e2e-adp-05', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000006', 'e2e-adp-06', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000007', 'e2e-adp-07', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000008', 'e2e-adp-08', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000009', 'e2e-adp-09', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000010', 'e2e-adp-10', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000011', 'e2e-adp-11', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0),
+    ('e2e00004-0000-0000-0000-000000000012', 'e2e-adp-12', '1.0.0', TRUE, 'FINAL',
+     'e2e00002-0000-0000-0000-000000000001', 'e2e00003-0000-0000-0000-000000000001',
+     '{}', '.', 'ROLE_ADMIN', FALSE, 0);

--- a/e2e/seed/encrypt-config.mjs
+++ b/e2e/seed/encrypt-config.mjs
@@ -1,0 +1,90 @@
+/*
+ * One-off helper to (re)generate the AES-GCM ciphertext used in the e2e baseline
+ * seed (V9999.01.01.1__e2e_baseline.sql) for `connector_instance_config.value`.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * Connector instance config is encrypted at rest (see crypto/AesGcmEncryptionService.kt).
+ * The mounted Flyway seed therefore has to store *ciphertext*, not plaintext, and
+ * that ciphertext must be decryptable by the app using the fixed e2e IKO_CRYPTO_KEY
+ * that docker-compose-e2e.yaml sets. This script reproduces the exact storage
+ * format the app uses so the seed values can be regenerated if the key changes.
+ *
+ * STORAGE FORMAT (must match AesGcmEncryptionService)
+ * ---------------------------------------------------
+ *   Base64( IV[12 bytes] || CIPHERTEXT || GCM_TAG[16 bytes] )
+ *   - AES-256-GCM (key is a 32-byte Base64 string)
+ *   - 12-byte random IV, 128-bit auth tag appended after the ciphertext
+ * The Java/JCE side reads IV = first 12 bytes and treats the remainder
+ * (ciphertext + tag) as one blob, which is exactly this layout.
+ *
+ * USAGE
+ * -----
+ *   node e2e/seed/encrypt-config.mjs
+ *   # or with an override key / custom values:
+ *   IKO_CRYPTO_KEY=<base64-aes-256-key> node e2e/seed/encrypt-config.mjs "value to encrypt"
+ *
+ * Each run produces a *fresh* random IV, so the Base64 output differs every time;
+ * any of those outputs is a valid ciphertext for the same plaintext. Paste the
+ * printed values into the seed SQL and update the plaintext comment next to them.
+ */
+
+import { randomBytes, createCipheriv, createDecipheriv } from "node:crypto";
+
+// Fixed e2e key — keep in sync with IKO_CRYPTO_KEY in docker-compose-e2e.yaml
+// (the same key application-test.yml uses).
+const KEY_B64 =
+    process.env.IKO_CRYPTO_KEY ?? "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=";
+
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+const key = Buffer.from(KEY_B64, "base64");
+
+function encrypt(plainText) {
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv("aes-256-gcm", key, iv, {
+        authTagLength: TAG_LENGTH,
+    });
+    const ciphertext = Buffer.concat([
+        cipher.update(plainText, "utf8"),
+        cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    return Buffer.concat([iv, ciphertext, tag]).toString("base64");
+}
+
+function decrypt(b64) {
+    const buf = Buffer.from(b64, "base64");
+    const iv = buf.subarray(0, IV_LENGTH);
+    const tag = buf.subarray(buf.length - TAG_LENGTH);
+    const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH);
+    const decipher = createDecipheriv("aes-256-gcm", key, iv, {
+        authTagLength: TAG_LENGTH,
+    });
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString(
+        "utf8",
+    );
+}
+
+// Default plaintext values used by the BRP personen connector instance, or the
+// single value passed as a CLI argument.
+const values =
+    process.argv.length > 2
+        ? process.argv.slice(2)
+        : [
+              "http://haalcentraal-personen:5010",
+              "file:/openapi-specs/haalcentraal-brp-personen.yaml",
+          ];
+
+for (const plain of values) {
+    const ct = encrypt(plain);
+    const roundtrip = decrypt(ct);
+    if (roundtrip !== plain) {
+        throw new Error(`Round-trip mismatch for "${plain}"`);
+    }
+    console.log(`plaintext : ${plain}`);
+    console.log(`ciphertext: ${ct}`);
+    console.log("");
+}

--- a/e2e/tests/admin/adp.spec.ts
+++ b/e2e/tests/admin/adp.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+import { AdpListPage } from "../../pages/AdpListPage";
+import { AdpFormPage, AdpEditForm } from "../../pages/AdpFormPage";
+
+/**
+ * Aggregated Data Profiles Admin UI coverage: add / edit / search / paginate.
+ *
+ * Runs in the `chromium` project, which loads the saved `storageState`, so every
+ * test starts already authenticated as `admin`.
+ *
+ * Baseline `e2e-adp-*` profiles are provided by the mounted Flyway seed
+ * (e2e/seed/V9999.01.01.1__e2e_baseline.sql) so search/pagination assertions hold
+ * regardless of test order or which create specs ran first. They reference the
+ * single seeded connector instance/endpoint (e2e-instance-01 / e2e-endpoint-01)
+ * that the Add form pre-selects. The add/edit tests use a per-run-unique suffix so
+ * reruns against a persistent DB do not collide with rows from an earlier run.
+ *
+ * The list page uses the identical shared selectors as the Connectors page
+ * (#profile-table, #search-bar, #search-results, #active-filter-toggle,
+ * #pagination-container) — AdpListPage mirrors ConnectorListPage exactly.
+ */
+
+const runId = Date.now().toString(36);
+
+test.describe("Aggregated Data Profiles Admin UI", () => {
+    test("baseline profiles are seeded and listed", async ({ page }) => {
+        const list = new AdpListPage(page);
+        await list.goto();
+        // The mounted seed inserted >= one page (10) of e2e-adp-* profiles.
+        expect(await list.rowCount()).toBeGreaterThan(0);
+        await list.searchFor("e2e-adp-01");
+        expect(await list.hasRowNamed("e2e-adp-01")).toBe(true);
+    });
+
+    test("add a profile via the modal; it appears in the list", async ({
+        page,
+    }) => {
+        const list = new AdpListPage(page);
+        const form = new AdpFormPage(page);
+        const name = `e2e-adp-created-${runId}`;
+
+        await list.goto();
+        await list.openAddModal();
+        // Name + roles only; the instance/endpoint selects default to the single
+        // seeded e2e instance/endpoint, and the JQ editors ship valid defaults.
+        await form.fillAdd({ name, roles: "ROLE_ADMIN" });
+        await form.submitCreate();
+
+        // Create pushes the URL to the new profile's detail page.
+        await expect(page).toHaveURL(
+            /\/admin\/aggregated-data-profiles\/[0-9a-f-]+/,
+        );
+
+        // Back on the list it is findable via search.
+        await list.goto();
+        await list.searchFor(name);
+        expect(await list.hasRowNamed(name)).toBe(true);
+    });
+
+    test("edit persists: change roles on a profile and reload", async ({
+        page,
+    }) => {
+        const list = new AdpListPage(page);
+        const form = new AdpFormPage(page);
+        const edit = new AdpEditForm(page);
+        const name = `e2e-adp-edit-${runId}`;
+        const newRoles = "ROLE_ADMIN,ROLE_USER";
+
+        // Create a fresh DRAFT profile to edit (FINAL profiles are immutable).
+        await list.goto();
+        await list.openAddModal();
+        await form.fillAdd({ name, roles: "ROLE_ADMIN" });
+        await form.submitCreate();
+        await expect(page).toHaveURL(
+            /\/admin\/aggregated-data-profiles\/[0-9a-f-]+/,
+        );
+        const detailUrl = page.url();
+
+        // Edit the roles on the General tab and save.
+        await edit.setRoles(newRoles);
+        await edit.submit();
+
+        // Reload the detail page; the new roles value must still be there.
+        await page.goto(detailUrl);
+        await expect(
+            page.locator("#profile-edit-form cds-text-input[name='roles']"),
+        ).toHaveAttribute("value", newRoles);
+    });
+
+    test("search filters the results", async ({ page }) => {
+        const list = new AdpListPage(page);
+        await list.goto();
+
+        await list.searchFor("e2e-adp-02");
+        expect(await list.hasRowNamed("e2e-adp-02")).toBe(true);
+        // A specific seeded name must not bring back unrelated baseline rows.
+        expect(await list.hasRowNamed("e2e-adp-11")).toBe(false);
+
+        await list.searchFor("no-such-profile-xyz");
+        await expect(
+            list.results.locator("cds-table-row", {
+                hasText: "No results found",
+            }),
+        ).toHaveCount(1);
+    });
+
+    test("paginate across the baseline rows", async ({ page }) => {
+        const list = new AdpListPage(page);
+        await list.goto();
+
+        // Restrict to the deterministic baseline set so page contents are stable
+        // regardless of any rows other specs created.
+        await list.searchFor("e2e-adp-");
+
+        const firstPageRows = await list.rows.allInnerTexts();
+        expect(firstPageRows.length).toBeGreaterThan(0);
+        // Page 1 (sorted by name asc) starts at e2e-adp-01.
+        expect(await list.hasRowNamed("e2e-adp-01")).toBe(true);
+
+        await list.goToPage(2);
+        // Page 2 shows later names and no longer the first one.
+        expect(await list.hasRowNamed("e2e-adp-11")).toBe(true);
+        expect(await list.hasRowNamed("e2e-adp-01")).toBe(false);
+    });
+});

--- a/e2e/tests/admin/connectors.spec.ts
+++ b/e2e/tests/admin/connectors.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "@playwright/test";
+import { ConnectorListPage } from "../../pages/ConnectorListPage";
+import { ConnectorFormPage } from "../../pages/ConnectorFormPage";
+
+/**
+ * Connectors Admin UI coverage: add / edit / search / paginate.
+ *
+ * Runs in the `chromium` project, which loads the saved `storageState`, so every
+ * test starts already authenticated as `admin`.
+ *
+ * Baseline `e2e-conn-*` connectors are provided by the mounted Flyway seed
+ * (e2e/seed/V9999.01.01.1__e2e_baseline.sql) so search/pagination assertions hold
+ * regardless of test order or which create specs ran first. The add/edit tests
+ * use a per-run-unique suffix so reruns against a persistent DB do not collide
+ * with rows created by an earlier run.
+ */
+
+const runId = Date.now().toString(36);
+
+test.describe("Connectors Admin UI", () => {
+    test("baseline connectors are seeded and listed", async ({ page }) => {
+        const list = new ConnectorListPage(page);
+        await list.goto();
+        // The mounted seed inserted >= one page (10) of e2e-conn-* connectors.
+        expect(await list.rowCount()).toBeGreaterThan(0);
+        await list.searchFor("e2e-conn-01");
+        expect(await list.hasRowNamed("e2e-conn-01")).toBe(true);
+    });
+
+    test("add a connector via the modal; it appears in the list", async ({
+        page,
+    }) => {
+        const list = new ConnectorListPage(page);
+        const form = new ConnectorFormPage(page);
+        const name = `e2e-created-${runId}`;
+
+        await list.goto();
+        await list.openAddModal();
+        await form.fillConnector({ name, reference: name });
+        await form.submit();
+
+        // Create pushes the URL to the new connector's detail page.
+        await expect(page).toHaveURL(/\/admin\/connectors\/[0-9a-f-]+/);
+
+        // Back on the list it is findable via search.
+        await list.goto();
+        await list.searchFor(name);
+        expect(await list.hasRowNamed(name)).toBe(true);
+    });
+
+    test("edit persists: add an instance to a connector and reload", async ({
+        page,
+    }) => {
+        const list = new ConnectorListPage(page);
+        const form = new ConnectorFormPage(page);
+        const connectorName = `e2e-edit-${runId}`;
+        const instanceName = `e2e-instance-${runId}`;
+
+        // Create a fresh (DRAFT) connector to edit.
+        await list.goto();
+        await list.openAddModal();
+        await form.fillConnector({ name: connectorName, reference: connectorName });
+        await form.submit();
+        await expect(page).toHaveURL(/\/admin\/connectors\/[0-9a-f-]+/);
+        const detailUrl = page.url();
+
+        // Add an instance (plain text fields) via the instance modal.
+        await page.locator("#instance-table cds-button[kind='primary']").click();
+        await expect(page.locator("#active-modal")).toBeVisible();
+        await form.fillInstance({
+            name: instanceName,
+            reference: instanceName,
+            apiSpecificationUrl: "https://example.com/openapi.yaml",
+        });
+        await form.submit();
+
+        // Reload the connector detail page; the instance must still be there.
+        await page.goto(detailUrl);
+        await expect(
+            page.locator("#instance-table cds-table-row", {
+                hasText: instanceName,
+            }),
+        ).toHaveCount(1);
+    });
+
+    test("search filters the results", async ({ page }) => {
+        const list = new ConnectorListPage(page);
+        await list.goto();
+
+        await list.searchFor("e2e-conn-02");
+        expect(await list.hasRowNamed("e2e-conn-02")).toBe(true);
+        // A specific seeded name must not bring back unrelated baseline rows.
+        expect(await list.hasRowNamed("e2e-conn-11")).toBe(false);
+
+        await list.searchFor("no-such-connector-xyz");
+        await expect(
+            list.results.locator("cds-table-row", { hasText: "No result found" }),
+        ).toHaveCount(1);
+    });
+
+    test("paginate across the baseline rows", async ({ page }) => {
+        const list = new ConnectorListPage(page);
+        await list.goto();
+
+        // Restrict to the deterministic baseline set so page contents are stable
+        // regardless of any rows other specs created.
+        await list.searchFor("e2e-conn-");
+
+        const firstPageRows = await list.rows.allInnerTexts();
+        expect(firstPageRows.length).toBeGreaterThan(0);
+        // Page 1 (sorted by name asc) starts at e2e-conn-01.
+        expect(await list.hasRowNamed("e2e-conn-01")).toBe(true);
+
+        await list.goToPage(2);
+        // Page 2 shows later names and no longer the first one.
+        expect(await list.hasRowNamed("e2e-conn-11")).toBe(true);
+        expect(await list.hasRowNamed("e2e-conn-01")).toBe(false);
+    });
+});

--- a/e2e/tests/admin/login.spec.ts
+++ b/e2e/tests/admin/login.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from "../../fixtures/auth";
+import { ADMIN_USER } from "../../fixtures/env";
+
+/**
+ * Smoke coverage for the Admin UI OAuth2/OIDC flow against live Keycloak:
+ *  - unauthenticated /admin redirects to the Keycloak login form;
+ *  - login as `admin` lands on /admin with the user's name/email rendered;
+ *  - logout leaves the authenticated landing page.
+ *
+ * This spec runs in the `smoke` project without a saved storageState so it
+ * exercises the real login form every run.
+ */
+
+test.describe("Admin UI login/logout", () => {
+    test("unauthenticated /admin redirects to Keycloak login form", async ({
+        loginPage,
+    }) => {
+        await loginPage.goto();
+        expect(await loginPage.isOnKeycloakLogin()).toBe(true);
+    });
+
+    test("admin can log in and reach the /admin landing page", async ({
+        loginPage,
+        page,
+    }) => {
+        await loginPage.goto();
+        await loginPage.loginAs(ADMIN_USER.username, ADMIN_USER.password);
+
+        await expect(page).toHaveURL(/\/admin/);
+        await expect(page.locator("#logout-link")).toBeVisible();
+        // The OIDC userinfo identity (full name from the `name` claim) is rendered
+        // in the header on the landing page.
+        await expect(page.locator(".header-user-name")).toContainText(
+            ADMIN_USER.fullName,
+        );
+    });
+
+    test("admin can log out", async ({ loginPage, page }) => {
+        await loginPage.goto();
+        await loginPage.loginAs(ADMIN_USER.username, ADMIN_USER.password);
+        await loginPage.logout();
+
+        // After logout the authenticated landing is no longer shown: either the
+        // Keycloak login form, or /admin re-prompting auth.
+        await expect(page.locator("#logout-link")).toHaveCount(0);
+    });
+});

--- a/e2e/tests/api/adp.spec.ts
+++ b/e2e/tests/api/adp.spec.ts
@@ -1,0 +1,55 @@
+import { expect, fetchAccessToken, test, WRONG_ROLE_USER } from "../../fixtures/api-token";
+import { APP_BASE_URL } from "../../fixtures/env";
+
+/**
+ * Public REST API: `/aggregated-data-profiles/{name}`.
+ *
+ * The seeded `e2e-brp-personen` profile (roles=ROLE_ADMIN) aggregates the single
+ * `e2e-brp` BRP endpoint and passes the mock envelope through unchanged ('.').
+ * A 200 here proves the full path: JWT -> AuthRoute role check -> connector route
+ * -> BRP mock -> aggregation -> response.
+ *
+ * Negative: unauthenticated -> 401; authenticated-without-ROLE_ADMIN -> 401
+ * (AggregatedDataProfileAccessDenied is mapped to 401 by the global error handler).
+ */
+
+const ADP_PATH = "/aggregated-data-profiles/e2e-brp-personen";
+
+test.describe("Public API: /aggregated-data-profiles", () => {
+    test("authenticated call returns 200 with data sourced from the BRP mock", async ({
+        apiContext,
+    }) => {
+        const res = await apiContext.get(ADP_PATH);
+        expect(res.status(), await res.text()).toBe(200);
+
+        // The result transform is '.', so the aggregated payload is the mock's
+        // own `{ type, personen }` envelope, surfaced under the ADP left/right shape.
+        const body = await res.json();
+        const serialized = JSON.stringify(body);
+        expect(serialized).toContain("RaadpleegMetBurgerservicenummer");
+        expect(serialized).toContain("personen");
+    });
+
+    test("unauthenticated call is rejected with 401", async ({
+        anonymousApiContext,
+    }) => {
+        const res = await anonymousApiContext.get(ADP_PATH);
+        expect(res.status()).toBe(401);
+    });
+
+    test("an authenticated user lacking ROLE_ADMIN is rejected", async ({
+        playwright,
+    }) => {
+        const tokenContext = await playwright.request.newContext();
+        const token = await fetchAccessToken(tokenContext, WRONG_ROLE_USER);
+        await tokenContext.dispose();
+
+        const context = await playwright.request.newContext({
+            baseURL: APP_BASE_URL,
+            extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+        });
+        const res = await context.get(ADP_PATH);
+        expect(res.status(), await res.text()).toBe(401);
+        await context.dispose();
+    });
+});

--- a/e2e/tests/api/endpoints.spec.ts
+++ b/e2e/tests/api/endpoints.spec.ts
@@ -1,0 +1,70 @@
+import { expect, fetchAccessToken, test, WRONG_ROLE_USER } from "../../fixtures/api-token";
+import { APP_BASE_URL } from "../../fixtures/env";
+
+/**
+ * Public REST API: `/endpoints/{connector}/{config}/{operation}`.
+ *
+ * Drives the seeded `e2e-brp` connector (instance `e2e-brp-instance`, operation
+ * `Personen`) which POSTs a RaadpleegMetBurgerservicenummer search to the BRP
+ * personen mock via Camel `rest-openapi`. The mock answers any valid query with
+ * an HTTP 200 `{ "type", "personen" }` envelope, so we assert on the envelope
+ * shape rather than a specific seeded BSN.
+ *
+ * Positive: bearer token whose `realm_access.roles` includes ROLE_ADMIN passes
+ * both the connector_endpoint_role check and reaches the mock.
+ * Negative: no token -> 401; the route is unreachable without authentication.
+ */
+
+const ENDPOINT_PATH = "/endpoints/e2e-brp/e2e-brp-instance/Personen";
+
+test.describe("Public API: /endpoints", () => {
+    test("authenticated call returns 200 with a payload from the BRP mock", async ({
+        apiContext,
+    }) => {
+        const res = await apiContext.get(ENDPOINT_PATH);
+        expect(res.status(), await res.text()).toBe(200);
+
+        const body = await res.json();
+        // The personen-mock envelope: a `type` discriminator and a `personen` array.
+        expect(body).toHaveProperty("type", "RaadpleegMetBurgerservicenummer");
+        expect(Array.isArray(body.personen)).toBe(true);
+    });
+
+    test("unauthenticated call is rejected with 401", async ({
+        anonymousApiContext,
+    }) => {
+        const res = await anonymousApiContext.get(ENDPOINT_PATH);
+        expect(res.status()).toBe(401);
+    });
+
+    test("a malformed bearer token is rejected with 401", async ({
+        playwright,
+    }) => {
+        const context = await playwright.request.newContext({
+            baseURL: APP_BASE_URL,
+            extraHTTPHeaders: { Authorization: "Bearer not-a-real-token" },
+        });
+        const res = await context.get(ENDPOINT_PATH);
+        expect(res.status()).toBe(401);
+        await context.dispose();
+    });
+
+    test("an authenticated user lacking ROLE_ADMIN is rejected (no endpoint role)", async ({
+        playwright,
+    }) => {
+        // `user` authenticates fine but holds only ROLE_USER, so it fails the
+        // connector_endpoint_role (ROLE_ADMIN) check inside Camel. The global error
+        // handler maps ConnectorAccessDenied -> 401.
+        const tokenContext = await playwright.request.newContext();
+        const token = await fetchAccessToken(tokenContext, WRONG_ROLE_USER);
+        await tokenContext.dispose();
+
+        const context = await playwright.request.newContext({
+            baseURL: APP_BASE_URL,
+            extraHTTPHeaders: { Authorization: `Bearer ${token}` },
+        });
+        const res = await context.get(ENDPOINT_PATH);
+        expect(res.status(), await res.text()).toBe(401);
+        await context.dispose();
+    });
+});

--- a/e2e/tests/auth.setup.ts
+++ b/e2e/tests/auth.setup.ts
@@ -1,0 +1,15 @@
+import { test as setup } from "@playwright/test";
+import { LoginPage } from "../pages/LoginPage";
+import { globalLoginAndSaveState } from "../fixtures/auth";
+
+/**
+ * `setup` project entry: logs in as admin against live Keycloak and saves the
+ * authenticated storageState to `.auth/admin.json`. Dependent projects load it
+ * via `storageState` so they start already authenticated.
+ */
+setup("authenticate as admin", async ({ page }) => {
+    const loginPage = new LoginPage(page);
+    await globalLoginAndSaveState(loginPage, (path) =>
+        page.context().storageState({ path }),
+    );
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "CommonJS",
+        "moduleResolution": "Node",
+        "lib": ["ES2022", "DOM"],
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": true,
+        "types": ["node"]
+    },
+    "include": ["**/*.ts"],
+    "exclude": ["node_modules", "playwright-report", "test-results"]
+}

--- a/scripts/wait-for-health.sh
+++ b/scripts/wait-for-health.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# wait-for-health.sh — poll a health URL until it reports {"status":"UP"} or a timeout elapses.
+#
+# Usage:
+#   ./scripts/wait-for-health.sh <health-url> [timeout-seconds] [interval-seconds]
+#
+# Example:
+#   ./scripts/wait-for-health.sh http://localhost:9090/actuator/health/readiness
+#
+# Optionally also polls a second URL for plain reachability (HTTP < 500), used to
+# gate on the Keycloak token endpoint before the Playwright suite logs in:
+#
+#   WAIT_FOR_URL=http://localhost:8082/auth/realms/valtimo/.well-known/openid-configuration \
+#     ./scripts/wait-for-health.sh http://localhost:9090/actuator/health/readiness
+#
+set -euo pipefail
+
+HEALTH_URL="${1:-http://localhost:9090/actuator/health/readiness}"
+TIMEOUT="${2:-300}"
+INTERVAL="${3:-5}"
+EXTRA_URL="${WAIT_FOR_URL:-}"
+
+log() {
+    printf '[wait-for-health] %s\n' "$1"
+}
+
+# Poll an arbitrary URL until curl gets an HTTP status < 500 (i.e. the service answers).
+wait_for_reachable() {
+    local url="$1"
+    local deadline=$(( $(date +%s) + TIMEOUT ))
+    log "waiting for reachability of ${url} (timeout ${TIMEOUT}s)"
+    while true; do
+        local code
+        code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "${url}" || echo 000)"
+        if [[ "${code}" =~ ^[1-4][0-9][0-9]$ ]]; then
+            log "${url} reachable (HTTP ${code})"
+            return 0
+        fi
+        if (( $(date +%s) >= deadline )); then
+            log "ERROR: timed out waiting for ${url} (last HTTP ${code})"
+            return 1
+        fi
+        sleep "${INTERVAL}"
+    done
+}
+
+# Poll a Spring Boot Actuator health URL until it reports status UP.
+wait_for_health_up() {
+    local url="$1"
+    local deadline=$(( $(date +%s) + TIMEOUT ))
+    log "waiting for ${url} to report UP (timeout ${TIMEOUT}s)"
+    while true; do
+        local body
+        body="$(curl -s --max-time 5 "${url}" || echo '')"
+        if echo "${body}" | grep -q '"status":"UP"'; then
+            log "${url} is UP"
+            return 0
+        fi
+        if (( $(date +%s) >= deadline )); then
+            log "ERROR: timed out waiting for ${url} to be UP"
+            log "last response: ${body:-<none>}"
+            return 1
+        fi
+        sleep "${INTERVAL}"
+    done
+}
+
+if [[ -n "${EXTRA_URL}" ]]; then
+    wait_for_reachable "${EXTRA_URL}"
+fi
+
+wait_for_health_up "${HEALTH_URL}"


### PR DESCRIPTION
[#251](https://github.com/Integraal-Klant-en-Objectbeeld/iko/issues/251) | [Artifacts](https://cloud.humanlayer.com/tasks/019ef8d4-c5e7-78f6-983d-04444df2399d/artifacts) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/tasks/019ef8d4-c5e7-78f6-983d-04444df2399d/artifacts)

## What problems was I solving

IKO had unit tests and `@Tag("integration")` tests, but both run against **mocked external systems and an in-process Spring context**. Nothing validated the assembled stack the way a real user or API client hits it:

- the **OAuth2/OIDC admin login** against a real Keycloak (authorization-code redirect, session cookie, CSRF, JS-driven logout);
- the **Carbon + HTMX admin screens** — Shadow-DOM web components, debounced `/filter` swaps, Ace editors syncing hidden textareas, modal close-on-`HX-Trigger`;
- the **public REST API** end to end: bearer JWT → resource-server filter → Camel per-endpoint / per-profile role check → connector route → external call.

A regression in any of those (a CSP nonce change breaking inline JS, a selector rename, a role-claim mapping drift) would pass the existing suites and only surface in manual testing. This PR adds a self-contained Playwright end-to-end suite plus the Docker Compose stack, CI workflow and mounted Flyway seed needed to boot a real app (app + Postgres + Redis + live Keycloak + a BRP personen mock) and drive it through a browser and over raw HTTP. **No production Kotlin or template is touched.**

## What user-facing changes did I ship

This PR adds developer/CI tooling only — no runtime behaviour changes. New surfaces:

- [.github/workflows/e2e.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e) — runs the Playwright suite on `rc/X.Y.Z` release-candidate branches; archives the HTML report.
- [docker-compose-e2e.yaml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-6e79a9b01bbb655eb533f39b7f7d1d4d50897e843f349ebb1d10b5edea89e32f) — the full e2e stack (built app image + Postgres + Redis + live Keycloak + BRP mock).
- [e2e/](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files) — new top-level Playwright project: 16 specs across login/logout, Connectors admin, ADP admin, and the public REST API.

## How I implemented it

The work was delivered in five phases (one per commit), each building on the previous.

### Stack & CI plumbing
- [docker-compose-e2e.yaml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-6e79a9b01bbb655eb533f39b7f7d1d4d50897e843f349ebb1d10b5edea89e32f) — builds the same app image CI ships. Keycloak runs with `--hostname keycloak` so the in-network issuer matches the host-published one (same host:port via 8082). Sets the fixed `IKO_CRYPTO_KEY`, the resource-server `authorities-claim-name=[roles]` (this realm emits a top-level `roles` claim, not `resource_access.iko.roles`), `SERVER_SERVLET_SESSION_COOKIE_SECURE=false` for plain HTTP, and `SPRING_FLYWAY_PLACEHOLDER_REPLACEMENT=false` so the BRP route's Camel `${...}` expressions store verbatim. Actuator published on 9090 for the readiness gate.
- [scripts/wait-for-health.sh](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-6e58ff9a75e2247d50d665ffb61e2fb99080deda64954ead8005e30fc1926b98) — polls `/actuator/health/readiness` until UP; optionally pre-gates on Keycloak reachability.
- [.github/workflows/e2e.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e) — `compose up --build` → wait-for-health → `npm ci` → install browsers → `playwright test` → `down -v` → upload report. Triggered only on `rc/*` branches.

### Test harness scaffold
- [e2e/playwright.config.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-6721a12dd017950a52c91e2ef0ea317334f78d0ecc2cc7b00b2af412e62d2373) — four projects: `setup` (login once → `storageState`), `smoke` (drives login/logout live, no saved state), `chromium` (authenticated admin specs, reuses session), `api` (headless HTTP). No `webServer` block — the stack is external.
- [e2e/fixtures/env.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-b1eb89347a8441d0328216f4078bbc861e3fe53f0c0227acbbcad83a9236fc3f) — central config; defaults to local compose ports + `valtimo` realm, overridable via `E2E_*` env.
- [e2e/package.json](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-a02b008b50077ce0795c0dee89c3b663ead543e6d790874baece325aee7f1043), [tsconfig.json](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-b5f32afdd9e8c14b02c570db855022a30aeb595e3dd1c3a71c187d685c0a2860), [.gitignore](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-e574c05f5f21381b12a5689a80afc369632845227ab212f6fc352dfe4e8c98ed), [package-lock.json](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-139617765b1e6e524ac53308ebacd758a4cef34c596b47f4ac3688652fd49518).

### Auth flow
- [e2e/pages/LoginPage.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-b48a36ad9f23ea8991d354e7a4bf7ea077378bbe048dd128178798cdde952e3d) — drives the Keycloak form; logout polls the off-canvas Carbon panel (toggling only while collapsed to survive hydration dropping an early click) then waits for the Keycloak login form rather than racing the multi-hop logout redirect.
- [e2e/fixtures/auth.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-915f80c198e2ddc723467afcd3c6f34b8c3fa8db89d1336a3ff86f30ef4e944f) + [e2e/tests/auth.setup.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-ec4113af7837c3c5a7a8fd60eedb7570d7ce6ff86b96a608c01abc22126fae8c) — log in as `admin` against live Keycloak, persist `storageState` to `.auth/admin.json`.
- [e2e/tests/admin/login.spec.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-2ed4ec2d6c55caaa5e7d6477a310fcdd12965bf7d8477620dba333eaea65dd0b) — smoke: unauthenticated `/admin` → Keycloak form; login renders the OIDC `name` claim; logout clears the session.

### Admin UI feature specs
- [e2e/pages/ConnectorListPage.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-3a089ad6435fb3428aaf2c7a676fbfaf098bd46e1bc8467c148491b8826c9cda) + [ConnectorFormPage.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-212f8f7edeb9d541ac2f36cb45404165c5e08cb1c0721d593f238973ed26f8ad) + [connectors.spec.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-84fd47ad4a9b8ea662c720498ff6c54052dafc395f4bc17f66dd2b3481851751) — add / edit (instance persists across reload) / search / paginate. Page Objects anchor on stable host IDs (`#search-bar input`, `#search-results cds-table-row`), wait on the `/filter` swap rather than a timeout, and drive the Ace connector-code editor via `el._editor.setValue()` so the submitted hidden textarea syncs.
- [e2e/pages/AdpListPage.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-ee18a0ae2e1e00ab914bf7e54efbc59a94379eab027747b80a7b43b8ea7a2d68) + [AdpFormPage.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-1a1e5aa6de8bfb553da203dacf388423dd91a5f493f5919a74ee2f680cdd1433) + [adp.spec.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-efbd9d891b7f6dfd850f3e82490910eecf7125aca333c2ff87852e7e7d78a562) — mirrors the Connectors flow on the shared `list.html`; covers the create modal, the inline General-tab roles edit (only mutable field on a DRAFT), search, and pagination.

### Public REST API + BRP mock
- [e2e/fixtures/api-token.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-71f294562fd26f619de2ea87c69fdfddbe433250b2b74e0ffa98587ff9277fcc) — OAuth2 password-grant token fixture; `apiContext` / `anonymousApiContext`; `WRONG_ROLE_USER` (`user`, authenticates but lacks ROLE_ADMIN) for the Camel role-check negative path.
- [e2e/tests/api/endpoints.spec.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-08ebe38b95a8a7a4498642702eead49ea42fa7d41d7ae9afa5ba7a7800e10284) + [api/adp.spec.ts](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-8773f2c296009687089feacc04d461f4b5c9514f6e65f9d3204f41ccdbd2d386) — 200 from the BRP mock with the expected envelope; 401 for anon / malformed token / wrong-role.

### Database / seed
- [e2e/seed/V9999.01.01.1__e2e_baseline.sql](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-f31b9f86614feb4e8b84e865c8777377eb47dcce0fe48bc789748c131d6e45d9) — mounted Flyway migration (via `SPRING_FLYWAY_LOCATIONS=...,filesystem:/seed`, kept out of `src/` so it can never reach production). Seeds 12 `e2e-conn-*` + 12 `e2e-adp-*` baseline rows (zero-padded for deterministic sort) plus the BRP connector + instance (encrypted config) + endpoint + `connector_endpoint_role` (ROLE_ADMIN) + ADP. The BRP route POSTs a RaadpleegMetBurgerservicenummer query to `haalcentraal-personen:5010` via `rest-openapi`.
- [e2e/seed/encrypt-config.mjs](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/194/files#diff-d2951a73ec9e09cac1a132a73ad23c81bf8ad1544fae5dd91204e657388c5f71) — reproduces `AesGcmEncryptionService`'s `Base64(IV||ciphertext||tag)` format to regenerate the seed's encrypted `connector_instance_config` values if the key changes.

## Deviations from the plan

No plan file was found in the task directory. One intentional deviation from the structure outline is documented inline in `docker-compose-e2e.yaml`: the outline proposed mapping authorities from `[realm_access][roles]` with audience `account`, but this realm's `iko` client emits a top-level `roles` claim with audience `iko`, so the compose env sets `authorities-claim-name=[roles]` and leaves the audience at the application default. The BRP connector route is also deliberately simpler than the production brp-wsgateway template (no Keycloak token exchange / mTLS) because the e2e mock is plain HTTP.

## How to verify it

### Manual Testing
```bash
docker compose -f docker-compose-e2e.yaml up -d --build
./scripts/wait-for-health.sh http://localhost:9090/actuator/health/readiness
cd e2e && npm ci && npx playwright install --with-deps
npx playwright test
npx playwright show-report   # inspect the HTML report
docker compose -f docker-compose-e2e.yaml down -v
```

- [ ] Stack boots and the readiness probe reports UP.
- [ ] All four Playwright projects (`setup`, `smoke`, `chromium`, `api`) pass.
- [ ] CI: push the branch as `rc/X.Y.Z` and confirm the `End-to-end (Playwright)` workflow runs and uploads the report artifact.

### Automated Tests
```bash
cd e2e
npm run typecheck   # tsc --noEmit
npm test            # playwright test (needs the e2e stack running)
```

## Description for the changelog

Add a Playwright end-to-end test suite (Admin UI login + Connectors/ADP screens + public REST API) with a Docker Compose stack and an rc-branch CI workflow.
