### PR TITLE
fix: seed empty JSON body so jq setBody works on null bodies

### DIFF
--- a/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
+++ b/src/main/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilder.kt
@@ -16,6 +16,7 @@
 
 package com.ritense.iko.connectors.camel
 
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_OPERATION_VARIABLE
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_TAG_VARIABLE
 import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_VERSION_VARIABLE
@@ -28,6 +29,17 @@ class TransformDispatcherRouteBuilder : RouteBuilder() {
         from(IkoRouteHelper.transform())
             .routeId("transform-dispatcher")
             .routeConfigurationId(GLOBAL_ERROR_HANDLER_CONFIGURATION)
+            // Endpoint transform routes commonly build their request body with a `setBody: jq:`
+            // step. Since Camel 4.18 the jq language throws InvalidPayloadException when the
+            // message body is null (e.g. a GET request without a body), because the body can no
+            // longer be converted to a JsonNode. Seed an empty JSON object as the payload when no
+            // body is present so jq expressions have a valid input to evaluate against.
+            .process { exchange ->
+                val body = exchange.message.body
+                if (body == null || (body is String && body.isBlank())) {
+                    exchange.message.body = JsonNodeFactory.instance.objectNode()
+                }
+            }
             .choice()
             .`when` { exchange ->
                 exchange.context.hasEndpoint(

--- a/src/test/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilderTest.kt
+++ b/src/test/kotlin/com/ritense/iko/connectors/camel/TransformDispatcherRouteBuilderTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.connectors.camel
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_OPERATION_VARIABLE
+import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_TAG_VARIABLE
+import com.ritense.iko.camel.IkoConstants.Variables.CONNECTOR_VERSION_VARIABLE
+import com.ritense.iko.camel.IkoRouteHelper.Companion.GLOBAL_ERROR_HANDLER_CONFIGURATION
+import org.apache.camel.builder.RouteBuilder
+import org.apache.camel.builder.RouteConfigurationBuilder
+import org.apache.camel.impl.DefaultCamelContext
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class TransformDispatcherRouteBuilderTest {
+
+    private lateinit var context: DefaultCamelContext
+
+    @BeforeEach
+    fun setUp() {
+        context = DefaultCamelContext()
+        // The dispatcher references this route configuration; declare an empty one for the test.
+        context.addRoutesConfigurations(
+            object : RouteConfigurationBuilder() {
+                override fun configuration() {
+                    routeConfiguration(GLOBAL_ERROR_HANDLER_CONFIGURATION)
+                }
+            },
+        )
+        context.addRoutes(TransformDispatcherRouteBuilder())
+        // Stand-in for a connector-supplied endpoint transform route that builds its request
+        // body from a header using a `setBody: jq:` step, mirroring the BRP connector.
+        context.addRoutes(
+            object : RouteBuilder() {
+                override fun configure() {
+                    from("direct:iko:endpoint:transform:test:1.0.0.Personen")
+                        .routeId("direct:iko:endpoint:transform:test:1.0.0.Personen")
+                        .setBody().jq("""{ burgerservicenummer: header("burgerservicenummer") }""")
+                }
+            },
+        )
+        context.start()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        context.stop()
+    }
+
+    @Test
+    fun `seeds an empty json body so jq setBody works with a null body`() {
+        val result = context.createProducerTemplate().send("direct:iko:endpoint:transform") { exchange ->
+            exchange.setVariable(CONNECTOR_TAG_VARIABLE, "test")
+            exchange.setVariable(CONNECTOR_VERSION_VARIABLE, "1.0.0")
+            exchange.setVariable(CONNECTOR_OPERATION_VARIABLE, "Personen")
+            exchange.message.setHeader("burgerservicenummer", "999993653")
+            exchange.message.body = null
+        }
+
+        assertThat(result.exception).isNull()
+        val body = result.message.getBody(JsonNode::class.java)
+        assertThat(body.get("burgerservicenummer").asText()).isEqualTo("999993653")
+    }
+}


### PR DESCRIPTION
# Fix BRP connector JSON body parsing on null bodies

[Artifacts](https://cloud.humanlayer.com/tasks/019efd9a-4801-79d1-b74b-e5dacc83a8a7/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019efd9a-4801-79d1-b74b-e5dacc83a8a7)

## What problems was I solving

Since 1.4.X, BRP connector users reported broken endpoint transforms. Connector endpoint transform routes commonly build their request body with a `setBody: jq:` step. Since Camel 4.18, the `jq` language throws `InvalidPayloadException` when the message body is `null` (e.g. a GET request without a body) because a null body can no longer be converted to a `JsonNode`.

The user worked around it by manually adding `setBody: constant: "{}"` + `unmarshal: json: {}` to the connector YAML. This PR fixes the root cause centrally so connectors don't need that workaround.

After this PR: endpoint transforms using `setBody: jq:` evaluate correctly even when no request body is present.

## What user-facing changes did I ship

- [TransformDispatcherRouteBuilder.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/195/files#diff-99446988994bcb6e3bbeb452221add060e58ec2fb9b19dd5a06109deecedfdc8) - Seed an empty JSON object as the body in the transform dispatcher when the body is null or blank, so downstream `jq` expressions have valid input.

## How I implemented it

### Backend Changes

- [TransformDispatcherRouteBuilder.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/195/files#diff-99446988994bcb6e3bbeb452221add060e58ec2fb9b19dd5a06109deecedfdc8R37) - Added a `.process { }` step at the head of the `transform-dispatcher` route, before the `choice()` dispatch. If `exchange.message.body` is `null` or a blank `String`, it sets the body to `JsonNodeFactory.instance.objectNode()` (`{}`). This runs once for every dispatched transform, so all connectors benefit without per-connector YAML changes. A code comment documents the Camel 4.18 `jq` behavior change driving the fix.

### Tests

- [TransformDispatcherRouteBuilderTest.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/195/files#diff-16e1da025f8d7466059d7e898644682b206ffddcdb60a2fb0738763b06804681) - New unit test. Builds a `DefaultCamelContext` with the dispatcher plus a stand-in endpoint transform route that mirrors the BRP pattern (`setBody().jq("{ burgerservicenummer: header(...) }")`). Sends an exchange with a `null` body and asserts no exception is thrown and the `jq` result is produced correctly.

## Deviations from the plan

No plan file found in the task directory.

## How to verify it

### Manual Testing

- [ ] Configure a connector endpoint transform that uses `setBody: jq:` (e.g. BRP `Personen`)
- [ ] Trigger the endpoint with a request that has no body (GET)
- [ ] Confirm the transform evaluates and no `InvalidPayloadException` occurs

### Automated Tests

```bash
./gradlew test --tests "com.ritense.iko.connectors.camel.TransformDispatcherRouteBuilderTest"
```

## Description for the changelog

Fix connector endpoint transforms that use `setBody: jq:` failing with `InvalidPayloadException` on null request bodies (Camel 4.18 regression).
