### PR TITLE
chore: bump version to 1.4.2 on main

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,4 @@ kotlin.daemon.jvmargs=-Xmx2g
 org.gradle.parallel=true
 org.gradle.configureondemand=true
 
-version=1.4.1
+version=1.4.2


### PR DESCRIPTION
[Artifacts](https://cloud.humanlayer.com/tasks/019efe9a-d086-71d9-a34a-615851e5ffa5/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019efe9a-d086-71d9-a34a-615851e5ffa5)

## What problems was I solving

The 1.4.2 release was cut, but `gradle.properties` on `main` still declared `version=1.4.1`. This hotfix aligns the build version with the actual released version so artifacts built from `main` are stamped `1.4.2`.

## What user-facing changes did I ship

- [gradle.properties](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/197/files#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19) - bump `version` from `1.4.1` to `1.4.2`

## How I implemented it

Single-line change on a hotfix branch off `main`.

- [gradle.properties](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/197/files#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19) - updated `version=1.4.1` → `version=1.4.2`

## Deviations from the plan

No plan file found.

## How to verify it

### Manual Testing
- [ ] Confirm `gradle.properties` shows `version=1.4.2`
- [ ] `./gradlew properties | grep version` reports `1.4.2`

### Automated Tests
No code changes; CI build suffices.

## Description for the changelog

Bump project version to 1.4.2 in gradle.properties.
