### PR TITLE
feat(security): token-driven admin session timeout (IKO-309)

### DIFF
--- a/src/main/kotlin/com/ritense/iko/mvc/controller/SessionController.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/SessionController.kt
@@ -16,8 +16,15 @@
 
 package com.ritense.iko.mvc.controller
 
+import com.ritense.iko.security.AdminSessionProperties
+import com.ritense.iko.security.AdminSessionTimeoutResolver
+import com.ritense.iko.security.SessionTimeout
 import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
@@ -25,16 +32,50 @@ import org.springframework.web.bind.annotation.RequestMapping
 /**
  * Keep-alive endpoint backing the "Continue" action of the session timeout
  * modal. The endpoint lives under `/admin`, so it is covered by the admin
- * filter chain and requires an authenticated session. Handling the request
- * touches the existing HTTP session, resetting its inactivity timer.
+ * filter chain and requires an authenticated session.
+ *
+ * Each ping refreshes the user's Keycloak token through the
+ * [OAuth2AuthorizedClientManager] (sliding the SSO idle timeout), re-resolves
+ * the session timeout from the new `refresh_expires_in`, aligns the servlet
+ * [jakarta.servlet.http.HttpSession] inactivity timer (capped at the static
+ * config max) and returns the recomputed [SessionTimeout] as JSON. If the
+ * refresh fails, the session is effectively dead and the ping returns `401`,
+ * driving the browser to log out.
  */
 @Controller
 @RequestMapping("/admin/session")
-internal class SessionController {
+internal class SessionController(
+    private val authorizedClientManager: OAuth2AuthorizedClientManager,
+    private val adminSessionTimeoutResolver: AdminSessionTimeoutResolver,
+    private val adminSessionProperties: AdminSessionProperties,
+) {
     @GetMapping("/ping")
-    fun ping(request: HttpServletRequest): ResponseEntity<Void> {
-        // Accessing the existing session resets its inactivity timer.
-        request.getSession(false)
-        return ResponseEntity.noContent().build()
+    fun ping(
+        request: HttpServletRequest,
+        authentication: Authentication,
+    ): ResponseEntity<SessionTimeout> {
+        val authorizeRequest = OAuth2AuthorizeRequest
+            .withClientRegistrationId(REGISTRATION_ID)
+            .principal(authentication)
+            .build()
+
+        // A failed/absent refresh means the Keycloak session is dead; log out.
+        authorizedClientManager.authorize(authorizeRequest)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+
+        val timeout = adminSessionTimeoutResolver.resolve(authentication)
+
+        // Align the servlet session idle timer with the token-derived timeout,
+        // capped so it never exceeds the static config max.
+        request.getSession(false)?.maxInactiveInterval =
+            timeout.timeoutSeconds
+                .coerceAtMost(adminSessionProperties.timeoutSeconds)
+                .toInt()
+
+        return ResponseEntity.ok(timeout)
+    }
+
+    companion object {
+        private const val REGISTRATION_ID = "keycloak"
     }
 }

--- a/src/main/kotlin/com/ritense/iko/mvc/controller/SessionTimeoutModelAttribute.kt
+++ b/src/main/kotlin/com/ritense/iko/mvc/controller/SessionTimeoutModelAttribute.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.mvc.controller
+
+import com.ritense.iko.security.AdminSessionTimeoutResolver
+import org.springframework.security.core.Authentication
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+
+/**
+ * Surfaces the per-session admin session timeout into every admin page model,
+ * replacing the static `@adminSessionProperties` SpEL references in
+ * `layout-internal.html`. Scoped to the admin controllers package, mirroring
+ * the per-user data pattern in [com.ritense.iko.mvc.controller.HomeController].
+ */
+@ControllerAdvice(basePackages = ["com.ritense.iko.mvc.controller"])
+internal class SessionTimeoutModelAttribute(
+    private val adminSessionTimeoutResolver: AdminSessionTimeoutResolver,
+) {
+    @ModelAttribute
+    fun sessionTimeout(authentication: Authentication?, model: Model) {
+        if (authentication == null) {
+            return
+        }
+        val timeout = adminSessionTimeoutResolver.resolve(authentication)
+        model.addAttribute("sessionTimeoutSeconds", timeout.timeoutSeconds)
+        model.addAttribute("sessionWarningSeconds", timeout.warningSeconds)
+    }
+}

--- a/src/main/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolver.kt
+++ b/src/main/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolver.kt
@@ -16,11 +16,15 @@
 
 package com.ritense.iko.security
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.security.core.Authentication
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.core.OAuth2RefreshToken
 import org.springframework.stereotype.Component
 import java.time.Clock
+import java.time.Instant
+import java.util.Base64
 
 /**
  * Per-session admin UI timeout, in seconds. The countdown shown by the
@@ -35,26 +39,36 @@ internal data class SessionTimeout(
  * Resolves the admin UI session timeout from the logged-in user's Keycloak
  * refresh-token expiry rather than the static [AdminSessionProperties] config.
  *
- * The timeout is the number of seconds remaining on the refresh token
- * (`refresh_expires_in`), which represents "time until forced re-login". The
- * warning window is derived as `min(configured warning-before, timeout / 2)` so
- * the JS `timeoutSec > warningSec` guard always holds.
+ * The timeout is the number of seconds remaining on the refresh token, which
+ * represents "time until forced re-login". The warning window is derived as
+ * `min(configured warning-before, timeout / 2)` so the JS `timeoutSec >
+ * warningSec` guard always holds.
  *
- * If the authorized client, refresh token or its expiry cannot be read, this
- * falls back to the static [AdminSessionProperties] defaults so an admin is
- * never locked out by a transient store issue.
+ * Spring's default token-response converter only populates the *access* token
+ * expiry (`expires_in`); it ignores Keycloak's non-standard `refresh_expires_in`,
+ * so [OAuth2RefreshToken.getExpiresAt] is virtually always `null`. Keycloak
+ * refresh tokens are JWTs carrying an `exp` claim, so when the stored expiry is
+ * missing this reads `exp` straight from the token payload.
+ *
+ * If the authorized client, refresh token or its expiry cannot be read (no
+ * client, opaque/unparseable token, missing `exp`), this falls back to the
+ * static [AdminSessionProperties] defaults so an admin is never locked out by a
+ * transient store issue.
  */
 @Component
 internal class AdminSessionTimeoutResolver(
     private val authorizedClientService: OAuth2AuthorizedClientService,
     private val adminSessionProperties: AdminSessionProperties,
     private val clock: Clock = Clock.systemUTC(),
+    private val objectMapper: ObjectMapper = ObjectMapper(),
 ) {
     fun resolve(authentication: Authentication): SessionTimeout {
-        val expiresAt = authorizedClientService
+        val refreshToken = authorizedClientService
             .loadAuthorizedClient<OAuth2AuthorizedClient>(REGISTRATION_ID, authentication.name)
             ?.refreshToken
-            ?.expiresAt
+
+        val expiresAt = refreshToken?.expiresAt
+            ?: refreshToken?.tokenValue?.let { refreshTokenJwtExpiry(it) }
 
         val timeoutSeconds = expiresAt
             ?.let { (it.epochSecond - clock.instant().epochSecond).coerceAtLeast(0) }
@@ -64,6 +78,24 @@ internal class AdminSessionTimeoutResolver(
 
         return SessionTimeout(timeoutSeconds, warningSeconds)
     }
+
+    /**
+     * Reads the `exp` claim (epoch seconds) from a Keycloak refresh-token JWT
+     * without verifying the signature: the token is held server-side and was
+     * issued by Keycloak over TLS, so this is only extracting the expiry already
+     * decided by the realm. Returns `null` for any non-JWT/opaque token, a
+     * malformed payload or a missing/non-numeric `exp`, driving the static
+     * fallback.
+     */
+    private fun refreshTokenJwtExpiry(tokenValue: String): Instant? = runCatching {
+        val parts = tokenValue.split(".")
+        if (parts.size < 2) return null
+        val payload = Base64.getUrlDecoder().decode(parts[1])
+        objectMapper.readTree(payload)
+            .get("exp")
+            ?.takeIf { it.isNumber }
+            ?.let { Instant.ofEpochSecond(it.asLong()) }
+    }.getOrNull()
 
     companion object {
         private const val REGISTRATION_ID = "keycloak"

--- a/src/main/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolver.kt
+++ b/src/main/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolver.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.security
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.stereotype.Component
+import java.time.Clock
+
+/**
+ * Per-session admin UI timeout, in seconds. The countdown shown by the
+ * session-timeout modal is derived from these values.
+ */
+internal data class SessionTimeout(
+    val timeoutSeconds: Long,
+    val warningSeconds: Long,
+)
+
+/**
+ * Resolves the admin UI session timeout from the logged-in user's Keycloak
+ * refresh-token expiry rather than the static [AdminSessionProperties] config.
+ *
+ * The timeout is the number of seconds remaining on the refresh token
+ * (`refresh_expires_in`), which represents "time until forced re-login". The
+ * warning window is derived as `min(configured warning-before, timeout / 2)` so
+ * the JS `timeoutSec > warningSec` guard always holds.
+ *
+ * If the authorized client, refresh token or its expiry cannot be read, this
+ * falls back to the static [AdminSessionProperties] defaults so an admin is
+ * never locked out by a transient store issue.
+ */
+@Component
+internal class AdminSessionTimeoutResolver(
+    private val authorizedClientService: OAuth2AuthorizedClientService,
+    private val adminSessionProperties: AdminSessionProperties,
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    fun resolve(authentication: Authentication): SessionTimeout {
+        val expiresAt = authorizedClientService
+            .loadAuthorizedClient<OAuth2AuthorizedClient>(REGISTRATION_ID, authentication.name)
+            ?.refreshToken
+            ?.expiresAt
+
+        val timeoutSeconds = expiresAt
+            ?.let { (it.epochSecond - clock.instant().epochSecond).coerceAtLeast(0) }
+            ?: adminSessionProperties.timeoutSeconds
+
+        val warningSeconds = minOf(adminSessionProperties.warningBeforeSeconds, timeoutSeconds / 2)
+
+        return SessionTimeout(timeoutSeconds, warningSeconds)
+    }
+
+    companion object {
+        private const val REGISTRATION_ID = "keycloak"
+    }
+}

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -104,7 +104,12 @@ class SecurityConfig {
 
     @Bean
     fun oidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository: ClientRegistrationRepository) = OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository).apply {
+        // Used when Keycloak RP-initiated logout can be performed (id token present).
         setPostLogoutRedirectUri("{baseUrl}/admin")
+        // Fallback when there is no id token to build an end-session request
+        // (e.g. the session/token already expired): without this the handler
+        // redirects to "/" instead of the admin entry point.
+        setDefaultTargetUrl("/admin")
     }
 
     @Order(Ordered.LOWEST_PRECEDENCE - 100)

--- a/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/ritense/iko/security/SecurityConfig.kt
@@ -27,6 +27,10 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
@@ -164,6 +168,25 @@ class SecurityConfig {
             }
 
         return http.build()
+    }
+
+    /**
+     * Authorized-client manager backed by a refresh-token provider. Used by the
+     * session keep-alive ping to exchange the stored refresh token for a new one
+     * at Keycloak, which slides the SSO idle timeout and yields a fresh
+     * `refresh_expires_in` for the recomputed session timeout.
+     */
+    @Bean
+    fun authorizedClientManager(
+        clientRegistrationRepository: ClientRegistrationRepository,
+        authorizedClientService: OAuth2AuthorizedClientService,
+    ): OAuth2AuthorizedClientManager = AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository,
+        authorizedClientService,
+    ).apply {
+        setAuthorizedClientProvider(
+            OAuth2AuthorizedClientProviderBuilder.builder().refreshToken().build(),
+        )
     }
 
     @Bean

--- a/src/main/resources/static/js/session-timeout.js
+++ b/src/main/resources/static/js/session-timeout.js
@@ -7,8 +7,10 @@
             return;
         }
 
-        const timeoutSec = parseInt(modal.dataset.timeoutSeconds, 10);
-        const warningSec = parseInt(modal.dataset.warningSeconds, 10);
+        // These start from the values rendered at login but are updated from
+        // each ping response as the Keycloak refresh token slides.
+        let timeoutSec = parseInt(modal.dataset.timeoutSeconds, 10);
+        let warningSec = parseInt(modal.dataset.warningSeconds, 10);
         if (
             !Number.isFinite(timeoutSec) ||
             !Number.isFinite(warningSec) ||
@@ -21,13 +23,13 @@
             return;
         }
 
-        const idleMs = (timeoutSec - warningSec) * 1000;
+        let idleMs = (timeoutSec - warningSec) * 1000;
         // Keep-alive throttle: while the user is active, ping the server at
         // most once per this interval so genuine activity actually extends the
         // server session (not just the in-browser timer). Half the idle window
         // keeps the ping comfortably ahead of the warning, capped at 60s so a
         // long production timeout still refreshes frequently enough.
-        const keepAliveThrottleMs = Math.max(
+        let keepAliveThrottleMs = Math.max(
             Math.min(idleMs / 2, 60000),
             1000,
         );
@@ -73,10 +75,48 @@
             startCountdown();
         }
 
+        // Adopt the refreshed timeout/warning returned by a ping so the
+        // countdown tracks the (slid) Keycloak refresh-token expiry instead of
+        // the initial render values.
+        function applyTimeout(data) {
+            if (!data) return;
+            const nextTimeout = parseInt(data.timeoutSeconds, 10);
+            const nextWarning = parseInt(data.warningSeconds, 10);
+            if (
+                !Number.isFinite(nextTimeout) ||
+                !Number.isFinite(nextWarning) ||
+                nextTimeout <= nextWarning
+            ) {
+                console.warn(
+                    "[session-timeout] ignoring invalid ping timeout/warning",
+                    { nextTimeout, nextWarning },
+                );
+                return;
+            }
+            timeoutSec = nextTimeout;
+            warningSec = nextWarning;
+            idleMs = (timeoutSec - warningSec) * 1000;
+            keepAliveThrottleMs = Math.max(
+                Math.min(idleMs / 2, 60000),
+                1000,
+            );
+        }
+
+        // Refresh the Keycloak token at the server. Resolves with the parsed
+        // {timeoutSeconds, warningSeconds} JSON on success, or rejects on a
+        // non-OK response (e.g. 401 when the refresh failed) so the caller can
+        // log out.
         function pingServer() {
             lastServerContact = Date.now();
             console.debug("[session-timeout] keep-alive ping");
-            return fetch("/admin/session/ping", { credentials: "same-origin" });
+            return fetch("/admin/session/ping", {
+                credentials: "same-origin",
+            }).then(function (response) {
+                if (!response.ok) {
+                    return Promise.reject(response.status);
+                }
+                return response.json();
+            });
         }
 
         function resetTimer() {
@@ -92,7 +132,14 @@
             if (warningActive) return;
             resetTimer();
             if (Date.now() - lastServerContact >= keepAliveThrottleMs) {
-                pingServer().catch(function () {});
+                pingServer()
+                    .then(function (data) {
+                        applyTimeout(data);
+                        resetTimer();
+                    })
+                    .catch(function () {
+                        logout();
+                    });
             }
         }
 
@@ -107,15 +154,12 @@
             if (event) event.preventDefault();
             console.debug("[session-timeout] continue clicked");
             pingServer()
-                .then(function (response) {
+                .then(function (data) {
                     warningActive = false;
                     clearInterval(countdownTimer);
                     modal.removeAttribute("open");
-                    if (response.ok) {
-                        resetTimer();
-                    } else {
-                        logout();
-                    }
+                    applyTimeout(data);
+                    resetTimer();
                 })
                 .catch(function () {
                     logout();

--- a/src/main/resources/templates/layout-internal.html
+++ b/src/main/resources/templates/layout-internal.html
@@ -403,10 +403,8 @@
             class="cds-theme-zone-g10"
             data-carbon-theme="g10"
             prevent-close-on-click-outside="true"
-            th:with="timeoutSeconds=${@adminSessionProperties.timeoutSeconds},
-                     warningSeconds=${@adminSessionProperties.warningBeforeSeconds}"
-            th:data-timeout-seconds="${timeoutSeconds}"
-            th:data-warning-seconds="${warningSeconds}"
+            th:data-timeout-seconds="${sessionTimeoutSeconds}"
+            th:data-warning-seconds="${sessionWarningSeconds}"
         >
             <cds-modal-header>
                 <cds-modal-heading>

--- a/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
+++ b/src/test/kotlin/com/ritense/iko/TestIkoApplication.kt
@@ -24,6 +24,7 @@ import org.springframework.boot.runApplication
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.jwt.JwtDecoder
 
@@ -44,6 +45,10 @@ internal class IkoTestConfiguration {
     @Bean
     @Primary
     fun clientRegistrationRepository(): ClientRegistrationRepository = mock(ClientRegistrationRepository::class.java)
+
+    @Bean
+    @Primary
+    fun authorizedClientService(): OAuth2AuthorizedClientService = mock(OAuth2AuthorizedClientService::class.java)
 }
 
 fun main(args: Array<String>) {

--- a/src/test/kotlin/com/ritense/iko/mvc/controller/SessionControllerTest.kt
+++ b/src/test/kotlin/com/ritense/iko/mvc/controller/SessionControllerTest.kt
@@ -16,23 +16,85 @@
 
 package com.ritense.iko.mvc.controller
 
+import com.ritense.iko.security.AdminSessionProperties
+import com.ritense.iko.security.AdminSessionTimeoutResolver
+import com.ritense.iko.security.SessionTimeout
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpSession
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import java.time.Duration
 
 class SessionControllerTest {
-    private val controller = SessionController()
+    private val authorizedClientManager = mock<OAuth2AuthorizedClientManager>()
+    private val adminSessionTimeoutResolver = mock<AdminSessionTimeoutResolver>()
+    private val adminSessionProperties = AdminSessionProperties(
+        timeout = Duration.ofMinutes(30),
+        warningBefore = Duration.ofMinutes(2),
+    )
+    private val authentication = mock<Authentication>()
+
+    private val controller = SessionController(
+        authorizedClientManager = authorizedClientManager,
+        adminSessionTimeoutResolver = adminSessionTimeoutResolver,
+        adminSessionProperties = adminSessionProperties,
+    )
 
     @Test
-    fun `ping touches the existing session and returns 204`() {
+    fun `ping refreshes the token, aligns the session and returns the resolved timeout`() {
+        val authorizedClient = mock<OAuth2AuthorizedClient>()
+        whenever(authorizedClientManager.authorize(any<OAuth2AuthorizeRequest>())).thenReturn(authorizedClient)
+        val timeout = SessionTimeout(timeoutSeconds = 600, warningSeconds = 120)
+        whenever(adminSessionTimeoutResolver.resolve(authentication)).thenReturn(timeout)
+        val session = mock<HttpSession>()
+        val request = mock<HttpServletRequest>()
+        whenever(request.getSession(false)).thenReturn(session)
+
+        val response = controller.ping(request, authentication)
+
+        assertThat(response.statusCode).isEqualTo(HttpStatus.OK)
+        assertThat(response.body).isEqualTo(timeout)
+        // 600s is below the 1800s static cap, so it is applied as-is.
+        verify(session).maxInactiveInterval = 600
+    }
+
+    @Test
+    fun `ping caps the servlet session interval at the static maximum`() {
+        val authorizedClient = mock<OAuth2AuthorizedClient>()
+        whenever(authorizedClientManager.authorize(any<OAuth2AuthorizeRequest>())).thenReturn(authorizedClient)
+        // Token-derived timeout exceeds the static 1800s max.
+        whenever(adminSessionTimeoutResolver.resolve(authentication))
+            .thenReturn(SessionTimeout(timeoutSeconds = 36000, warningSeconds = 120))
+        val session = mock<HttpSession>()
+        val request = mock<HttpServletRequest>()
+        whenever(request.getSession(false)).thenReturn(session)
+
+        controller.ping(request, authentication)
+
+        verify(session).maxInactiveInterval = 1800
+    }
+
+    @Test
+    fun `ping returns 401 and does not resolve a timeout when the refresh fails`() {
+        whenever(authorizedClientManager.authorize(any<OAuth2AuthorizeRequest>())).thenReturn(null)
         val request = mock<HttpServletRequest>()
 
-        val response = controller.ping(request)
+        val response = controller.ping(request, authentication)
 
-        verify(request).getSession(false)
-        assertThat(response.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+        assertThat(response.statusCode).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(response.body).isNull()
+        verify(adminSessionTimeoutResolver, never()).resolve(any())
+        verify(request, never()).getSession(eq(false))
     }
 }

--- a/src/test/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolverTest.kt
+++ b/src/test/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolverTest.kt
@@ -29,6 +29,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.Base64
 
 class AdminSessionTimeoutResolverTest {
     private val now = Instant.parse("2026-06-26T12:00:00Z")
@@ -113,6 +114,53 @@ class AdminSessionTimeoutResolverTest {
 
         assertThat(result.timeoutSeconds).isEqualTo(1800)
         assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `derives timeout from the refresh-token JWT exp claim when the stored expiry is null`() {
+        // Spring leaves OAuth2RefreshToken.expiresAt null (it ignores refresh_expires_in);
+        // the exp claim in the JWT payload (now + 300s) must be used instead.
+        stubRefreshTokenJwt(expSeconds = now.plusSeconds(300).epochSecond)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(300)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `falls back to static defaults when the refresh token is opaque (not a JWT)`() {
+        val client = mock<OAuth2AuthorizedClient>()
+        whenever(client.refreshToken).thenReturn(OAuth2RefreshToken("opaque-token-no-dots", now, null))
+        stubAuthorizedClient(client)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `falls back to static defaults when the JWT payload has no exp claim`() {
+        val payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("""{"sub":"admin"}""".toByteArray())
+        val client = mock<OAuth2AuthorizedClient>()
+        whenever(client.refreshToken).thenReturn(OAuth2RefreshToken("header.$payload.sig", now, null))
+        stubAuthorizedClient(client)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    private fun stubRefreshTokenJwt(expSeconds: Long) {
+        val payload = Base64.getUrlEncoder().withoutPadding()
+            .encodeToString("""{"exp":$expSeconds}""".toByteArray())
+        val client = mock<OAuth2AuthorizedClient>()
+        // expiresAt left null, mirroring what Spring actually stores for Keycloak.
+        whenever(client.refreshToken).thenReturn(OAuth2RefreshToken("header.$payload.sig", now, null))
+        stubAuthorizedClient(client)
     }
 
     private fun stubRefreshTokenExpiringAt(expiresAt: Instant) {

--- a/src/test/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolverTest.kt
+++ b/src/test/kotlin/com/ritense/iko/security/AdminSessionTimeoutResolverTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2026 Den Haag, Ritense, Rotterdam, Utrecht, the Netherlands.
+ *
+ * Licensed under EUPL, Version 1.2 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ritense.iko.security
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.core.OAuth2RefreshToken
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+
+class AdminSessionTimeoutResolverTest {
+    private val now = Instant.parse("2026-06-26T12:00:00Z")
+    private val clock = Clock.fixed(now, ZoneOffset.UTC)
+    private val authorizedClientService = mock<OAuth2AuthorizedClientService>()
+    private val adminSessionProperties = AdminSessionProperties(
+        timeout = Duration.ofMinutes(30),
+        warningBefore = Duration.ofMinutes(2),
+    )
+    private val authentication = mock<Authentication>().also {
+        whenever(it.name).thenReturn("admin")
+    }
+
+    private val resolver = AdminSessionTimeoutResolver(
+        authorizedClientService = authorizedClientService,
+        adminSessionProperties = adminSessionProperties,
+        clock = clock,
+    )
+
+    @Test
+    fun `derives timeout from refresh-token expiry and caps warning at half the timeout when shorter than configured`() {
+        // Refresh token expires in 200 seconds; configured warning-before is 120s,
+        // but timeout/2 = 100s is shorter, so warning is capped at 100s.
+        stubRefreshTokenExpiringAt(now.plusSeconds(200))
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(200)
+        assertThat(result.warningSeconds).isEqualTo(100)
+    }
+
+    @Test
+    fun `keeps the configured warning-before when it is shorter than half the timeout`() {
+        // Refresh token expires in 1800 seconds; timeout/2 = 900s, configured 120s is shorter.
+        stubRefreshTokenExpiringAt(now.plusSeconds(1800))
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `clamps a past expiry to zero`() {
+        stubRefreshTokenExpiringAt(now.minusSeconds(60))
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(0)
+        assertThat(result.warningSeconds).isEqualTo(0)
+    }
+
+    @Test
+    fun `falls back to static defaults when no authorized client is found`() {
+        stubAuthorizedClient(null)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `falls back to static defaults when the refresh token is absent`() {
+        val client = mock<OAuth2AuthorizedClient>()
+        whenever(client.refreshToken).thenReturn(null)
+        stubAuthorizedClient(client)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    @Test
+    fun `falls back to static defaults when the refresh token has no expiry`() {
+        val client = mock<OAuth2AuthorizedClient>()
+        whenever(client.refreshToken).thenReturn(OAuth2RefreshToken("refresh-token-value", now, null))
+        stubAuthorizedClient(client)
+
+        val result = resolver.resolve(authentication)
+
+        assertThat(result.timeoutSeconds).isEqualTo(1800)
+        assertThat(result.warningSeconds).isEqualTo(120)
+    }
+
+    private fun stubRefreshTokenExpiringAt(expiresAt: Instant) {
+        // issuedAt must precede expiresAt per the OAuth2RefreshToken contract; pick a
+        // point just before the expiry so the "past expiry" case can also be modelled.
+        val issuedAt = expiresAt.minusSeconds(1)
+        val client = mock<OAuth2AuthorizedClient>()
+        whenever(client.refreshToken).thenReturn(OAuth2RefreshToken("refresh-token-value", issuedAt, expiresAt))
+        stubAuthorizedClient(client)
+    }
+
+    private fun stubAuthorizedClient(client: OAuth2AuthorizedClient?) {
+        whenever(
+            authorizedClientService.loadAuthorizedClient<OAuth2AuthorizedClient>(eq("keycloak"), eq("admin")),
+        ).thenReturn(client)
+    }
+}


### PR DESCRIPTION
## Header Links

[IKO-309](https://github.com/Integraal-Klant-en-Objectbeeld/iko-issues/issues/309) | [Artifacts](https://cloud.humanlayer.com/tasks/019f0312-0b6a-7408-8126-ec0fb322de45/artifacts) | [Task deep link](https://cloud.humanlayer.com/deep/tasks/019f0312-0b6a-7408-8126-ec0fb322de45) | [PR Walkthrough (alpha)](https://cloud.humanlayer.com/artifacts/019f0396-838b-7eac-bb53-92f15d74208f)

## What problems was I solving

The admin UI session timeout was static and identity-blind. Every admin got the same hard-coded idle window from `iko.security.admin.session.timeout` (30m), unrelated to the actual lifetime of their Keycloak session. Two consequences:

- The session-timeout modal countdown showed a flat 30m for everyone, regardless of how much life was left on their Keycloak refresh token.
- The keep-alive ping only *touched* the servlet session (reset its inactivity timer) but never refreshed the Keycloak token, so the SSO idle window did not slide. An admin actively working past the static window could be logged out even though their refresh token was still valid.

After this PR, the timeout is **per-session and identity-aware**: it is derived from the logged-in user's Keycloak refresh-token expiry (`refresh_expires_in`), the keep-alive ping actually refreshes the token (sliding the SSO idle window), and any unreadable expiry or failed refresh falls back to today's static values — no regression, no lockout.

## What user-facing changes did I ship

- [src/main/resources/templates/layout-internal.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-59b72572f18390374863b28cd3f6ca4bcf6f2ec7cbd326aa92f9c241b29c4243) - The session-timeout modal countdown now reflects the time left on the user's refresh token instead of a flat 30m.
- [src/main/resources/static/js/session-timeout.js](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-92519eef809ae8be99e56155e2931f1735820c3f627c4b6e5dcdd25288bd2ffa) - "Doorgaan" (Continue) and background keep-alive pings now refresh the Keycloak token and reset the countdown to the slid timeout; a failed refresh logs the user out.
- The countdown now actually reflects the user's refresh-token lifetime — without the JWT-`exp` fix below it silently fell back to the static 30m for every session.
- An expired-session logout now lands on `/admin` instead of the application root `/`.

## How I implemented it

Two phases, one commit each.

### Phase 1 — Per-session timeout at initial render

- [security/AdminSessionTimeoutResolver.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-9c482778c0cab08240e3559a85f6e4bd8276b910dcd533900492cd32dfa7798a) (new) - Declares `SessionTimeout(timeoutSeconds, warningSeconds)` and a resolver that loads the `keycloak`-registration `OAuth2AuthorizedClient` by principal name, reads `refreshToken?.expiresAt`, computes `timeoutSeconds = (expiresAt - now).coerceAtLeast(0)` against an injectable `Clock`, derives `warningSeconds = min(configured warning-before, timeout / 2)`, and falls back to `AdminSessionProperties` on any null in the chain.
- [mvc/controller/SessionTimeoutModelAttribute.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-457d8a270f1cbec3fd0aca2f38f73b8d94664a521739878506e2036dbfa75e1e) (new) - `@ControllerAdvice` scoped to the admin controllers package, exposing `sessionTimeoutSeconds` / `sessionWarningSeconds` model attributes (mirrors the `HomeController` per-user data pattern). Guards a null `Authentication`.
- [templates/layout-internal.html](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-59b72572f18390374863b28cd3f6ca4bcf6f2ec7cbd326aa92f9c241b29c4243) - Replaces the static `@adminSessionProperties` SpEL bean lookup on `#session-timeout-modal` with the model attributes; same `data-*` attribute names, so the JS reads them unchanged.

### Phase 2 — Token-refreshing keep-alive ping

- [security/SecurityConfig.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-94a779e45249ae101a181ecc2bafc16bf411289964f6e164d44ecc54a3a79258) - Adds an `OAuth2AuthorizedClientManager` bean (`AuthorizedClientServiceOAuth2AuthorizedClientManager` + `OAuth2AuthorizedClientProviderBuilder.builder().refreshToken().build()`) that exchanges the stored refresh token for a fresh one at Keycloak.
- [mvc/controller/SessionController.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-1e70aa7cc041f96951cf887b2aa6aed8b157007169e9b7e39dcea61e3b586fcb) - `ping()` now refreshes the token through the manager (returns `401` if `authorize` yields null), re-resolves the timeout, sets `HttpSession.maxInactiveInterval` to `timeoutSeconds.coerceAtMost(static max)`, and returns the `SessionTimeout` as JSON. Return type changed from `ResponseEntity<Void>` (204) to `ResponseEntity<SessionTimeout>` (200).
- [static/js/session-timeout.js](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-92519eef809ae8be99e56155e2931f1735820c3f627c4b6e5dcdd25288bd2ffa) - `timeoutSec`/`warningSec`/`idleMs`/`keepAliveThrottleMs` are now mutable. `pingServer()` resolves with parsed JSON on `response.ok`, rejects on non-OK. A new `applyTimeout(data)` helper adopts the refreshed values (same validity guard as init). Both the throttled activity ping and the "Doorgaan" handler apply the refreshed timeout and reset the countdown on success, and call `logout()` on failure (the `401` path).

### Follow-up fixes (commits 3 & 4)

These two commits fix bugs found during manual testing — without them the feature silently no-ops.

- **Refresh-token expiry from the JWT `exp` claim** — [security/AdminSessionTimeoutResolver.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-9c482778c0cab08240e3559a85f6e4bd8276b910dcd533900492cd32dfa7798a). Spring's default token-response converter only populates the *access*-token expiry (`expires_in`) and **ignores Keycloak's non-standard `refresh_expires_in`**, so `OAuth2RefreshToken.expiresAt` was always `null` and the resolver fell back to the static 30m for every session (this is why changing the realm idle timeout had no visible effect). Keycloak refresh tokens are JWTs carrying an `exp` claim, so when the stored `expiresAt` is missing the resolver now base64-decodes the token payload and reads `exp` directly (no signature verification — the token is held server-side and was issued over TLS). Opaque/unparseable tokens or a missing `exp` still fall back to the static defaults.
- **Expired-session logout redirect** — [security/SecurityConfig.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-94a779e45249ae101a181ecc2bafc16bf411289964f6e164d44ecc54a3a79258). `OidcClientInitiatedLogoutSuccessHandler` only appends the post-logout redirect to Keycloak's end-session request, which needs an id token. When the session/token has already expired there is no id token, so the handler fell back to its default target URL `/`. Added `setDefaultTargetUrl("/admin")` so expired-session logout lands on the admin entry point in both paths.

### Tests

- [test/.../security/AdminSessionTimeoutResolverTest.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-1b32c88e244ce910cd953c1dec88720cbe350531b345ad5dc302a6e6df9c95bf) (new) - 9 tests: warning cap at timeout/2, configured-warning kept when shorter, past-expiry clamp to zero, JWT-`exp` derivation when stored expiry is null, opaque-token + missing-`exp` fallbacks, and the 3 original static-fallback branches (no client / no refresh token / no expiry), all with a fixed `Clock`.
- [test/.../controller/SessionControllerTest.kt](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/198/files#diff-b353045c43d84ec781b96241ec78f8518d5765d6cf3a5cc4f2687247bf9f4f63) - Rewritten for the new constructor: success → `200` + capped `maxInactiveInterval`, over-cap value clamps to `1800`, null `authorize` → `401` without touching the resolver or session.

## Deviations from the plan

No plan file was generated for this task (implemented directly from the structure outline via `implement-outline`). Two minor judgment calls worth flagging against the outline:

- The outline's resolver sketch used `Instant.now()` directly; the injected `Clock` (already declared in the outline's signature) was wired into the computation so tests can assert exact `timeoutSeconds` against a fixed clock.
- The outline's JS diff snippet only showed the activity-path `pingServer` change. Since `pingServer()` was changed to resolve with parsed JSON / reject on non-OK, the existing `continueSession` ("Doorgaan") handler was updated to match — keeping a single ping contract and the same `401`→logout behavior.
- The outline (and research §5) assumed `OAuth2RefreshToken.expiresAt` would carry the Keycloak expiry. It does not — Spring ignores `refresh_expires_in` — so a follow-up commit reads the expiry from the refresh-token JWT `exp` claim instead. See "Follow-up fixes" above.

## How to verify it

### Worktree setup

```bash
git fetch origin
git checkout feature/token-driven-session-timeout-309
```

### Manual Testing

- [ ] Start the docker stack + app, log in as an admin; in DevTools confirm `#session-timeout-modal` `data-timeout-seconds` ≈ refresh-token remaining (≈ `ssoSessionIdleTimeout` 1800s minus elapsed), not a flat 30m, and `data-warning-seconds` = `min(120, timeout/2)`.
- [ ] Go idle until the warning modal shows, click "Doorgaan" — confirm the ping returns JSON, the countdown resets to the refreshed (slid) timeout, and the Keycloak SSO idle window slides.
- [ ] Force a refresh failure (revoke/expire the refresh token, or stop Keycloak), trigger a ping, and confirm the `401` drives `window.ikoLogout()` (redirect to `/admin`).
- [ ] Confirm an active admin past the static 30m is no longer logged out at 30m (servlet session now tracks the slid token), but still bounded by realm `ssoSessionMaxLifespan`.
- [ ] Simulate a missing authorized client / expiry and confirm the modal falls back to the static `30m` / `2m`.
- [ ] Lower realm `valtimo` **SSO Session Idle** (e.g. 1m), re-login, and confirm the modal countdown tracks the new value (verifies the JWT-`exp` fix — previously stuck at 30m).
- [ ] Let the session fully expire and confirm logout redirects to `/admin`, not `/`.

### Automated Tests

```bash
./gradlew compileKotlin compileTestKotlin
./gradlew test --tests "*AdminSessionTimeoutResolverTest" --tests "*SessionControllerTest"
./gradlew test
./gradlew spotlessCheck
```

## Description for the changelog

Admin UI session timeout is now derived per-user from the Keycloak refresh-token expiry (read from the token's JWT `exp` claim), with the keep-alive ping refreshing the token and sliding the SSO idle window (static config retained as a safe fallback).
