### PR TITLE
fix(e2e): resolve Keycloak issuer host on CI runner for browser auth flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,16 @@ jobs:
                     cache: npm
                     cache-dependency-path: e2e/package-lock.json
 
+            # Keycloak runs with a fixed `--hostname keycloak`, so every issuer /
+            # authorization / logout URL it emits uses `http://keycloak:8082`. The
+            # browser-driven OAuth2 auth-code flow is redirected to that host and must
+            # resolve it, otherwise Chromium fails with net::ERR_NAME_NOT_RESOLVED.
+            # In-network (app -> Keycloak) and the password-grant API specs resolve it
+            # via Docker DNS, but the host running Playwright does not. Map it to the
+            # published loopback port, mirroring the documented local setup.
+            -   name: Map Keycloak hostname to loopback
+                run: echo "127.0.0.1 keycloak" | sudo tee -a /etc/hosts
+
             -   name: Bring up e2e stack
                 run: docker compose -f docker-compose-e2e.yaml up -d --build
 

--- a/docker-compose-e2e.yaml
+++ b/docker-compose-e2e.yaml
@@ -4,10 +4,14 @@ name: iko-e2e
 #
 # Brings up the built app image (same Dockerfile as snapshot-releases.yml) plus
 # Postgres, Redis and a live Keycloak importing the `valtimo` realm. Keycloak runs
-# with `--hostname keycloak` so its issuer URI resolves inside the compose network
-# (no /etc/hosts hack). The app's OAuth2 issuer URIs point at the in-network
-# `http://keycloak:8082/auth/realms/valtimo`, while the browser/token clients on the
-# host reach Keycloak via the published 8082 port (same host:port, so issuer matches).
+# with `--hostname keycloak` so every issuer / authorization / logout URL it emits
+# uses `http://keycloak:8082`. The app's OAuth2 issuer URIs point at the in-network
+# `http://keycloak:8082/auth/realms/valtimo` and resolve via Docker DNS. The
+# password-grant API specs hit the published 8082 port directly (issuer matches,
+# since Keycloak stamps `keycloak:8082` regardless), but the browser-driven
+# auth-code flow is redirected to the `keycloak` host and must resolve it too —
+# so the host running Playwright maps `127.0.0.1 keycloak` in /etc/hosts (see the
+# e2e workflow and the local setup in CLAUDE.md).
 #
 # Actuator is published on 9090 for the readiness gate (scripts/wait-for-health.sh).
 #


### PR DESCRIPTION
[Fix E2E test failure](https://github.com/Integraal-Klant-en-Objectbeeld/iko/actions/runs/29012523804/job/86099363360) | [Artifacts](https://cloud.humanlayer.com/tasks/019f4680-f864-75ef-8e3c-ab3ad0038c73/artifacts) | [Task](https://cloud.humanlayer.com/deep/tasks/019f4680-f864-75ef-8e3c-ab3ad0038c73)

## What problems was I solving

The Playwright end-to-end suite was failing on CI during the browser-driven OAuth2
authorization-code login flow. Keycloak is started with a fixed `--hostname keycloak`,
so every issuer, authorization, and logout URL it emits points at `http://keycloak:8082`.
Inside the compose network the app resolves that host via Docker DNS, and the
password-grant API specs hit the published `8082` port directly (the issuer still
matches, since Keycloak stamps `keycloak:8082` regardless). But the **host running
Playwright** has no way to resolve `keycloak`, so when Chromium follows the auth-code
redirect it fails with `net::ERR_NAME_NOT_RESOLVED` and the whole browser login flow
dies.

After this PR the CI runner resolves the `keycloak` hostname to the published loopback
port, mirroring the documented local setup (`127.0.0.1 keycloak` in `/etc/hosts`), so
the browser auth-code flow completes and the e2e suite passes.

## What user-facing changes did I ship

No runtime/application changes — CI and test-infrastructure only.

- [.github/workflows/e2e.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/200/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e) — new step maps `127.0.0.1 keycloak` into the runner's `/etc/hosts` before bringing up the stack.
- [docker-compose-e2e.yaml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/200/files#diff-6e79a9b01bbb655eb533f39b7f7d1d4d50897e843f349ebb1d10b5edea89e32f) — header comment rewritten to explain why the host needs the `/etc/hosts` mapping (comment only; no config change).

## How I implemented it

### CI Changes
- [.github/workflows/e2e.yml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/200/files#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31e) — added a `Map Keycloak hostname to loopback` step (`echo "127.0.0.1 keycloak" | sudo tee -a /etc/hosts`) placed after Node setup and before `docker compose ... up -d`, with a comment explaining that the browser-driven auth-code flow is redirected to `keycloak:8082` and Chromium must resolve it.

### Documentation
- [docker-compose-e2e.yaml](https://github.com/Integraal-Klant-en-Objectbeeld/iko/pull/200/files#diff-6e79a9b01bbb655eb533f39b7f7d1d4d50897e843f349ebb1d10b5edea89e32f) — updated the file's header comment to distinguish the three resolution paths (in-network app → Keycloak via Docker DNS, password-grant API specs via published port, browser auth-code flow via host `/etc/hosts`) and cross-reference the e2e workflow and local setup in `CLAUDE.md`.

## Deviations from the plan

No plan file found for this task.

## How to verify it

### Manual Testing
- [ ] Trigger the `e2e` workflow on this branch and confirm the run is green.
- [ ] Confirm the browser-driven login spec no longer fails with `net::ERR_NAME_NOT_RESOLVED`.
- [ ] Confirm the `Map Keycloak hostname to loopback` step runs before `Bring up e2e stack`.

### Automated Tests
The full e2e Playwright suite runs in the `e2e` GitHub Actions workflow on this branch.

## Description for the changelog

Fix e2e failure by resolving the `keycloak` issuer host on the CI runner so the browser-driven OAuth2 auth-code login flow completes.
